### PR TITLE
chore: 🤖 clean up unneeded nuke user keys

### DIFF
--- a/modules/codebuild_job/data.tf
+++ b/modules/codebuild_job/data.tf
@@ -3,13 +3,13 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 data "aws_ssm_parameter" "access_key_id" {
-  name = "/ci/user/access_key_id"
+  name = var.aws_access_key_id_ssm_path
 
   with_decryption = true
 }
 
 data "aws_ssm_parameter" "secret_access_key" {
-  name = "/ci/user/secret_access_key"
+  name = var.aws_secret_access_key_ssm_path
 
   with_decryption = true
 }

--- a/modules/codebuild_job/locals.tf
+++ b/modules/codebuild_job/locals.tf
@@ -11,6 +11,7 @@ locals {
       var.allowed_resource_arns,
       [
         "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/ci/*",
+        "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/nuke/*",
         "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:key/*",
         "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:alias/*"
       ]

--- a/modules/codebuild_job/variables.tf
+++ b/modules/codebuild_job/variables.tf
@@ -128,12 +128,12 @@ variable "report_build_status" {
 
 # tfsec:ignore:sensitive-in-variable
 variable "aws_access_key_id_ssm_path" {
- description = "Path to our ssm access key"
- default = "/ci/user/access_key_id"
+  description = "Path to our ssm access key"
+  default     = "/ci/user/access_key_id"
 }
 
 # tfsec:ignore:sensitive-in-variable
 variable "aws_secret_access_key_ssm_path" {
   description = "Path to access to our smm secret access key"
-  default = "/ci/user/secret_access_key" 
+  default     = "/ci/user/secret_access_key"
 }

--- a/modules/codebuild_job/variables.tf
+++ b/modules/codebuild_job/variables.tf
@@ -125,3 +125,15 @@ variable "report_build_status" {
   type        = bool
   default     = false
 }
+
+# tfsec:ignore:sensitive-in-variable
+variable "aws_access_key_id_ssm_path" {
+ description = "Path to our ssm access key"
+ default = "/ci/user/access_key_id"
+}
+
+# tfsec:ignore:sensitive-in-variable
+variable "aws_secret_access_key_ssm_path" {
+  description = "Path to access to our smm secret access key"
+  default = "/ci/user/secret_access_key" 
+}


### PR DESCRIPTION
As we are assuming a role with temporary credentials using `aws sts assume-role` command. We no longer need to store a permanent set of keys/secrets in ssm.