### PR TITLE
Update base_vpc output to include execute api prefix list

### DIFF
--- a/modules/base_vpc/outputs.tf
+++ b/modules/base_vpc/outputs.tf
@@ -23,8 +23,8 @@ output "vpc_endpoint_dynamodb_prefix_list_id" {
   value       = module.vpc_endpoints.endpoints.*.dynamodb[0].prefix_list_id
 }
 
-output "vpc_endpoint_execute_api_prefix_list_id" {
-  description = "The id for the execute API prefix list"
+output "vpc_endpoint_audit_log_api_prefix_list_id" {
+  description = "The id for the audit log API gateway prefix list"
   value       = module.vpc_endpoints.endpoints.*.execute_api[0].prefix_list_id
 }
 

--- a/modules/base_vpc/outputs.tf
+++ b/modules/base_vpc/outputs.tf
@@ -23,6 +23,11 @@ output "vpc_endpoint_dynamodb_prefix_list_id" {
   value       = module.vpc_endpoints.endpoints.*.dynamodb[0].prefix_list_id
 }
 
+output "vpc_endpoint_execute_api_prefix_list_id" {
+  description = "The id for the execute API prefix list"
+  value       = module.vpc_endpoints.endpoints.*.execute_api[0].prefix_list_id
+}
+
 output "security_group_ids" {
   description = "A map of security group ids"
   value = {


### PR DESCRIPTION
This PR updates `base_vpc` module to output execute API prefix list.