### PR TITLE
fix: 🐛 grant CI role perm to PutRolePolicy on nuke role

### DIFF
--- a/modules/base_vpc/README.md
+++ b/modules/base_vpc/README.md
@@ -47,6 +47,7 @@ Opinionated model to set up a private vpc with service endpoints
 | <a name="output_private_subnet_cidrs"></a> [private\_subnet\_cidrs](#output\_private\_subnet\_cidrs) | A list of private cidr blocks |
 | <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | A list of private subnets |
 | <a name="output_security_group_ids"></a> [security\_group\_ids](#output\_security\_group\_ids) | A map of security group ids |
+| <a name="output_vpc_endpoint_audit_log_api_prefix_list_id"></a> [vpc\_endpoint\_audit\_log\_api\_prefix\_list\_id](#output\_vpc\_endpoint\_audit\_log\_api\_prefix\_list\_id) | The id for the audit log API gateway prefix list |
 | <a name="output_vpc_endpoint_dynamodb_prefix_list_id"></a> [vpc\_endpoint\_dynamodb\_prefix\_list\_id](#output\_vpc\_endpoint\_dynamodb\_prefix\_list\_id) | The id for the dynamodb prefix list |
 | <a name="output_vpc_endpoint_s3_prefix_list_id"></a> [vpc\_endpoint\_s3\_prefix\_list\_id](#output\_vpc\_endpoint\_s3\_prefix\_list\_id) | The id for the s3 prefix list |
 | <a name="output_vpc_endpoints"></a> [vpc\_endpoints](#output\_vpc\_endpoints) | A map of our vpc endpoints |

--- a/modules/opensearch/README.md
+++ b/modules/opensearch/README.md
@@ -18,10 +18,10 @@ Module to provision opensearch and using the opensearch api create a basic index
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.72.0 |
-| <a name="provider_elasticsearch"></a> [elasticsearch](#provider\_elasticsearch) | 2.0.0-beta.3 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.0.1 |
-| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | = 3.72.0 |
+| <a name="provider_elasticsearch"></a> [elasticsearch](#provider\_elasticsearch) | = 2.0.0-beta.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | = 3.0.1 |
+| <a name="provider_template"></a> [template](#provider\_template) | n/a |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.7.2 |
 
 ## Modules

--- a/modules/shared_account_child_access/policies/child_ci_policy_part1.json.tpl
+++ b/modules/shared_account_child_access/policies/child_ci_policy_part1.json.tpl
@@ -96,6 +96,7 @@
         "arn:aws:iam::${account_id}:role/cjse-*",
         "arn:aws:iam::${account_id}:role/vpc-flow-logs-role-cjse-*",
         "arn:aws:iam::${account_id}:role/Bichard7-Administrator-Access",
+        "arn:aws:iam::${account_id}:role/Bichard7-Aws-Nuke-Access",
         "arn:aws:iam::${account_id}:policy/bichard-7-*",
         "arn:aws:iam::${account_id}:policy/cjse-*",
         "arn:aws:iam::${account_id}:policy/vpc-flow-logs-role-cjse-*"


### PR DESCRIPTION
fixes this error in the `apply-codebuild-layer` code build job:

```
│ Error: Error putting IAM role policy AllCodeBuildBucketAccess: AccessDenied: User: arn:aws:sts::454061736096:assumed-role/Bichard7-CI-Access/1643069111800306733 is not authorized to perform: iam:PutRolePolicy on resource: role Bichard7-Aws-Nuke-Access
```