### PR TITLE
Add function_name_without_prefix to s3_lambda output

### DIFF
--- a/modules/s3_lambda/outputs.tf
+++ b/modules/s3_lambda/outputs.tf
@@ -7,3 +7,8 @@ output "function_name" {
   description = "The name of the Lambda Function"
   value       = aws_lambda_function.lambda.function_name
 }
+
+output "function_name_without_prefix" {
+  description = "The name of the Lambda Function without the prefix"
+  value       = var.function_name
+}


### PR DESCRIPTION
Added `function_name_without_prefix` to `s3_lambda` module output
We will use this output value to output all lambda function names in the audit logging layer.