### PR TITLE
fix: 🐛 buggy grafana dir

### DIFF
--- a/modules/codebuild_monitoring/README.md
+++ b/modules/codebuild_monitoring/README.md
@@ -78,7 +78,6 @@ Provisions a monitoring cluster with the following components
 | [grafana_dashboard.codebuild_last_build_status_dashboard](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/dashboard) | resource |
 | [grafana_dashboard.codebuild_status_dashboard](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/dashboard) | resource |
 | [grafana_data_source.cloudwatch](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/data_source) | resource |
-| [grafana_folder.codebuild_vpc_stats](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/folder) | resource |
 | [grafana_user.admin_user](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/user) | resource |
 | [grafana_user.readonly_user](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/user) | resource |
 | [random_password.admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |

--- a/modules/codebuild_monitoring/grafana_dashboards.tf
+++ b/modules/codebuild_monitoring/grafana_dashboards.tf
@@ -6,13 +6,8 @@ resource "grafana_dashboard" "codebuild_status_dashboard" {
   config_json = file("${path.module}/dashboards/codebuild-pass-fail-status.json")
 }
 
-resource "grafana_folder" "codebuild_vpc_stats" {
-  title = "Codebuild VPC"
-}
-
 resource "grafana_dashboard" "codebuild_ecs_stats" {
   config_json = file("${path.module}/dashboards/aws-ecs_rev7.json")
-  folder      = grafana_folder.codebuild_vpc_stats.id
 }
 
 resource "grafana_dashboard" "codebuild_last_build_status_dashboard" {


### PR DESCRIPTION
terraform is getting confused about the existence of a folder. We don't need the folder as there are only 4 dashboards for ci. This removes the folder and puts the dashboard with the others in the General folder