### PR TITLE
fix: 🐛 es provider requires current ssm pw

### DIFF
--- a/modules/opensearch/README.md
+++ b/modules/opensearch/README.md
@@ -85,6 +85,7 @@ $ARTIFACT_BUCKET=xxx aws-vault exec your-shared-credentials -- ./scripts/upload_
 | [aws_security_group_rule.elasticsearch_ingress_from_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.snapshot_lambda_egress](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.snapshot_lambda_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/security_group_rule) | resource |
+| [aws_ssm_parameter.es_password](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.os_user](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/ssm_parameter) | resource |
 | [elasticsearch_kibana_object.cloudwatch_index_pattern](https://registry.terraform.io/providers/phillbaker/elasticsearch/2.0.0-beta.4/docs/resources/kibana_object) | resource |
 | [elasticsearch_opendistro_ism_policy.prune_indices_after_n_days](https://registry.terraform.io/providers/phillbaker/elasticsearch/2.0.0-beta.4/docs/resources/opendistro_ism_policy) | resource |

--- a/modules/opensearch/main.tf
+++ b/modules/opensearch/main.tf
@@ -10,6 +10,15 @@ resource "random_password" "os" {
   min_lower   = 1
 }
 
+resource "aws_ssm_parameter" "es_password" {
+  name      = "/${var.name}/es/master/password"
+  type      = "SecureString"
+  value     = random_password.os.result
+  overwrite = true
+
+  tags = var.tags
+}
+
 resource "aws_kms_key" "secret_encryption_key" {
   description             = "${var.name} secret key"
   deletion_window_in_days = 10

--- a/modules/opensearch/providers.tf
+++ b/modules/opensearch/providers.tf
@@ -1,7 +1,8 @@
 provider "elasticsearch" {
-  url                   = "https://${aws_elasticsearch_domain.os.endpoint}"
-  username              = local.os_user_name
-  password              = aws_secretsmanager_secret_version.os_password.secret_string
+  url      = "https://${aws_elasticsearch_domain.os.endpoint}"
+  username = local.os_user_name
+  #password              = jsondecode(aws_secretsmanager_secret_version.os_password.secret_string)
+  password              = aws_ssm_parameter.es_password.value
   sniff                 = false
   aws_region            = data.aws_region.current.name
   healthcheck           = false


### PR DESCRIPTION
Codebuild error

```
│ Error: HEAD healthcheck failed: This is usually due to network or permission issues. The underlying error isn't accessible, please debug by disabling healthchecks.
```