### PR TITLE
fix: 🐛 role name so ci can attach policy

### DIFF
--- a/modules/opensearch/secrets_rotation_lambda.tf
+++ b/modules/opensearch/secrets_rotation_lambda.tf
@@ -37,7 +37,7 @@ resource "aws_iam_policy" "allow_lambda_secretsmanager" {
 }
 
 resource "aws_iam_role" "iam_for_secrets_rotation_lambda" {
-  name = "iam_for_lambda"
+  name = "bichard-7-secrets-rotation-lambda"
 
   assume_role_policy = <<EOF
 {


### PR DESCRIPTION
There is a prefix for roles which allows CI to perform actions on the roles/ policies, that was missing on this role.