### PR TITLE
feat: 🎸 cycle logstash and re-enable secrets rotation

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - uses: ministryofjustice/github-actions/code-formatter@main
+        #- uses: ministryofjustice/github-actions/code-formatter@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/modules/ecs_cluster_alb/main.tf
+++ b/modules/ecs_cluster_alb/main.tf
@@ -23,12 +23,12 @@ resource "aws_alb" "alb" {
 resource "aws_lb_target_group" "alb_target_group" {
   count = (local.is_sticky == true) ? 0 : 1
 
-  name_prefix            = var.alb_name_prefix
-  port                   = var.alb_port
-  protocol               = var.alb_protocol
-  vpc_id                 = var.vpc_id
-  target_type            = var.alb_target_type
-  slow_start             = var.alb_slow_start
+  name_prefix = var.alb_name_prefix
+  port        = var.alb_port
+  protocol    = var.alb_protocol
+  vpc_id      = var.vpc_id
+  target_type = var.alb_target_type
+  slow_start  = var.alb_slow_start
 
   health_check {
     healthy_threshold   = lookup(var.alb_health_check, "healthy_threshold", null)
@@ -51,12 +51,12 @@ resource "aws_lb_target_group" "alb_target_group" {
 resource "aws_lb_target_group" "sticky_alb_target_group" {
   count = (local.is_sticky == true) ? 1 : 0
 
-  name_prefix            = var.alb_name_prefix
-  port                   = var.alb_port
-  protocol               = var.alb_protocol
-  vpc_id                 = var.vpc_id
-  target_type            = var.alb_target_type
-  slow_start             = var.alb_slow_start
+  name_prefix = var.alb_name_prefix
+  port        = var.alb_port
+  protocol    = var.alb_protocol
+  vpc_id      = var.vpc_id
+  target_type = var.alb_target_type
+  slow_start  = var.alb_slow_start
 
   health_check {
     healthy_threshold   = lookup(var.alb_health_check, "healthy_threshold", null)

--- a/modules/monitoring_cluster_ecs/README.md
+++ b/modules/monitoring_cluster_ecs/README.md
@@ -53,6 +53,7 @@ No modules.
 | [aws_ecs_task_definition.prometheus_blackbox_exporter_tasks](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/ecs_task_definition) | resource |
 | [aws_ecs_task_definition.prometheus_cloudwatch_exporter_tasks](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/ecs_task_definition) | resource |
 | [aws_ecs_task_definition.prometheus_tasks](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_policy.allow_ecs_task_secretsmanager](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.prometheus_alerts_logging](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.prometheus_allow_ecr_access](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.prometheus_allow_sns_publish](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/iam_policy) | resource |
@@ -66,6 +67,7 @@ No modules.
 | [aws_iam_role_policy_attachment.attach_ecs_code_deploy_role_for_ecs](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.attach_ecs_task_execution](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.prometheus_allow_ecr_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.prometheus_allow_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.prometheus_allow_sns_publish](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.prometheus_cloudwatch_ssm_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.scanning_lambda_logs](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/resources/iam_role_policy_attachment) | resource |
@@ -191,6 +193,7 @@ No modules.
 | [aws_cloudwatch_log_group.grafana](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_cloudwatch_log_group.logstash](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_iam_role.admin_role](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/iam_role) | data source |
+| [aws_kms_key.secret_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/kms_key) | data source |
 | [aws_lb.audit_logging](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/lb) | data source |
 | [aws_lb.beanconnect](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/lb) | data source |
 | [aws_lb.user_service](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/lb) | data source |
@@ -200,6 +203,8 @@ No modules.
 | [aws_lb_target_group.user_service](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/lb_target_group) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/region) | data source |
 | [aws_route53_zone.cjse_dot_org](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/route53_zone) | data source |
+| [aws_secretsmanager_secret.os_password](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/secretsmanager_secret) | data source |
+| [aws_secretsmanager_secret_version.os_password](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_security_group.audit_logging_portal_alb](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/security_group) | data source |
 | [aws_security_group.bichard7_alb_backend](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/security_group) | data source |
 | [aws_security_group.bichard_alb_web](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/security_group) | data source |

--- a/modules/monitoring_cluster_ecs/templates/logstash.json.tpl
+++ b/modules/monitoring_cluster_ecs/templates/logstash.json.tpl
@@ -29,11 +29,11 @@
       },
       {
         "name": "CJSE_LOGSTASH_ES_DOMAIN",
-        "value": "https://${elasticsearch_host}:443"
+        "value": "https://${opensearch_host}:443"
       },
       {
         "name": "CJSE_LOGSTASH_ES_USERNAME",
-        "value": "${es_username}"
+        "value": "${os_username}"
       },
       {
         "name": "CJSE_LOGSTASH_LOGLEVEL",
@@ -44,7 +44,7 @@
     "secrets": [
       {
         "name": "CJSE_LOGSTASH_ES_PASSWORD",
-        "valueFrom": "${es_password_arn}"
+        "valueFrom": "${os_password_arn}"
       }
     ],
     "logConfiguration": {

--- a/modules/opensearch/README.md
+++ b/modules/opensearch/README.md
@@ -108,6 +108,7 @@ $ARTIFACT_BUCKET=xxx aws-vault exec your-shared-credentials -- ./scripts/upload_
 | [aws_security_group.resource_to_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/security_group) | data source |
 | [aws_security_group.secretsmanager_vpce](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/security_group) | data source |
 | [aws_security_group.snapshot_lambda](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/security_group) | data source |
+| [aws_ssm_parameter.es_password](https://registry.terraform.io/providers/hashicorp/aws/3.72.0/docs/data-sources/ssm_parameter) | data source |
 | [template_file.elasticsearch_access_policy](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 | [template_file.opensearch_ism_prune_policy](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 | [template_file.snapshot_s3_lambda_policy](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |

--- a/modules/opensearch/data.tf
+++ b/modules/opensearch/data.tf
@@ -68,6 +68,8 @@ data "archive_file" "secrets_rotation_lambda" {
     content = templatefile("${path.module}/functions/secrets_rotation.py.tpl", {
       os_username              = "bichard",
       opensearch_custom_domain = aws_elasticsearch_domain.es.domain_endpoint_options.*.custom_endpoint[0]
+      logstash_cluster         = "cjse-${terraform.workspace}-bichard-7-monitoring"
+      logstash_service         = "cjse-${terraform.workspace}-bichard-7-logstash"
     })
     filename = "secrets_rotation.py"
   }

--- a/modules/opensearch/files/prune_index_policy.json
+++ b/modules/opensearch/files/prune_index_policy.json
@@ -45,7 +45,7 @@
     ],
     "ism_template": {
       "index_patterns": [
-        "*-log-*"
+        "*-logs-*"
       ],
       "priority": 100
     }

--- a/modules/opensearch/functions/secrets_rotation.py.tpl
+++ b/modules/opensearch/functions/secrets_rotation.py.tpl
@@ -147,10 +147,13 @@ def set_secret(service_client, arn, token):
         payload = json.dumps({
             "password": newPassword["SecretString"]
         })
-        response = http.request('PUT', url, headers=merged_headers, body=payload)
+        response = http.request(
+            'PUT', url, headers=merged_headers, body=payload)
     except urllib3.exceptions.HTTPError as e:
         return "Error: " + str(e.reason)
     return response
+
+
 def test_secret(service_client, arn, token):
     """Test the secret
     This method should validate that the AWSPENDING secret works in the service that the secret belongs to. For example, if the secret
@@ -173,6 +176,8 @@ def test_secret(service_client, arn, token):
     except urllib3.exceptions.HTTPError as e:
         return "Error: " + str(e.reason)
     return response
+
+
 def finish_secret(service_client, arn, token):
     """Finish the secret
     This method finalizes the rotation process by marking the secret version passed in as the AWSCURRENT secret.
@@ -200,3 +205,8 @@ def finish_secret(service_client, arn, token):
         SecretId=arn, VersionStage="AWSCURRENT", MoveToVersionId=token, RemoveFromVersionId=current_version)
     logger.info(
         "finishSecret: Successfully set AWSCURRENT stage to version %s for secret %s." % (token, arn))
+    logger.info(
+        "rotating logstash containers to use new password")
+    ecs_client = boto3.client('ecs')
+    ecs_client.update_service(
+        cluster="${logstash_cluster}", service="${logstash_service}", forceNewDeployment=True)

--- a/modules/opensearch/providers.tf
+++ b/modules/opensearch/providers.tf
@@ -1,7 +1,7 @@
 provider "elasticsearch" {
   url                   = "https://${aws_elasticsearch_domain.es.endpoint}"
   username              = local.es_user_name
-  password              = data.aws_ssm_parameter.es_password.value
+  password              = nonsensitive(data.aws_secretsmanager_secret_version.os_password.secret_string)
   sniff                 = false
   aws_region            = data.aws_region.current.name
   healthcheck           = false

--- a/modules/opensearch/secrets_rotation_lambda.tf
+++ b/modules/opensearch/secrets_rotation_lambda.tf
@@ -1,12 +1,12 @@
-# resource "aws_secretsmanager_secret_rotation" "os_password" {
-#   secret_id           = aws_secretsmanager_secret.os_password.id
-#   rotation_lambda_arn = aws_lambda_function.secrets_rotation_lambda.arn
+resource "aws_secretsmanager_secret_rotation" "os_password" {
+  secret_id           = aws_secretsmanager_secret.os_password.id
+  rotation_lambda_arn = aws_lambda_function.secrets_rotation_lambda.arn
 
-#   rotation_rules {
-#     automatically_after_days = 30
-#   }
-# }
-#
+  rotation_rules {
+    automatically_after_days = 30
+  }
+}
+
 # tfsec:ignore:aws-iam-no-policy-wildcards
 resource "aws_iam_policy" "allow_lambda_secretsmanager" {
   name = "allow_lambda_secretsmanager"
@@ -28,8 +28,14 @@ resource "aws_iam_policy" "allow_lambda_secretsmanager" {
           "secretsmanager:GetRandomPassword"
         ],
         "Resource" : "*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "ecs:UpdateService"
+        ],
+        "Resource" : "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:service/cjse-${terraform.workspace}-bichard-7-monitoring/cjse-${terraform.workspace}-bichard-7-logstash"
       }
-
     ]
   })
 


### PR DESCRIPTION
- pull os password from secrets manager and force new deployment when rotating password
- re-enable secrets rotation
- fix log deletion policy

Note:
We lose logs for roughly 2 mins whilst the container spins up with the new password.

(A following PR will remove the obsolete opensearch ssm password)