### PR TITLE
Draft: Remove AWSLogs prefix from ALB logging S3 filename

### DIFF
--- a/modules/audit_logging_ecs/main.tf
+++ b/modules/audit_logging_ecs/main.tf
@@ -14,7 +14,7 @@ resource "aws_ssm_parameter" "audit_logging_deploy_tag" {
 }
 
 module "audit_logging_portal_ecs_alb" {
-  source = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb"
+  source = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb?ref=remove-AWSLogs-s3-prefix"
 
   alb_security_groups = [
     data.aws_security_group.audit_logging_portal_alb.id

--- a/modules/beanconnect_ecs_task/main.tf
+++ b/modules/beanconnect_ecs_task/main.tf
@@ -22,7 +22,7 @@ resource "aws_ssm_parameter" "beanconnect_password" {
 }
 
 module "beanconnect_ecs_alb" {
-  source = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb"
+  source = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb?ref=remove-AWSLogs-s3-prefix"
   alb_listener = [
     {
       port     = 31004

--- a/modules/bichard7_ecs_task/main.tf
+++ b/modules/bichard7_ecs_task/main.tf
@@ -1,5 +1,5 @@
 module "bichard_ecs_alb" {
-  source              = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb"
+  source              = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb?ref=remove-AWSLogs-s3-prefix"
   alb_name            = local.alb_name
   alb_name_prefix     = "b7app"
   alb_port            = 9443

--- a/modules/codebuild_monitoring/grafana.tf
+++ b/modules/codebuild_monitoring/grafana.tf
@@ -37,7 +37,7 @@ module "codebuild_monitoring_ecs_cluster" {
 }
 
 module "codebuild_monitoring_ecs_alb" {
-  source              = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb"
+  source              = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb?ref=remove-AWSLogs-s3-prefix"
   alb_name            = local.grafana_alb_name
   alb_name_prefix     = local.grafana_alb_name_prefix
   service_subnets     = var.service_subnets

--- a/modules/ecs_cluster_alb/main.tf
+++ b/modules/ecs_cluster_alb/main.tf
@@ -10,7 +10,7 @@ resource "aws_alb" "alb" {
   access_logs {
     bucket  = var.logging_bucket_name
     enabled = (var.load_balancer_type == "application" && var.enable_alb_logging) ? true : false
-    prefix  = "alb/AWSLogs/${data.aws_caller_identity.current.account_id}/${var.alb_name}"
+    prefix  = "alb/${data.aws_caller_identity.current.account_id}/${var.alb_name}"
   }
 
   enable_deletion_protection = (lower(var.tags["is-production"]) == "true") ? true : false

--- a/modules/monitoring_cluster_ecs/blackbox_exporter.tf
+++ b/modules/monitoring_cluster_ecs/blackbox_exporter.tf
@@ -52,7 +52,7 @@ resource "aws_alb" "prometheus_blackbox_exporter_alb" {
   access_logs {
     bucket  = var.logging_bucket_name
     enabled = true
-    prefix  = "alb/AWSLogs/${data.aws_caller_identity.current.account_id}/${local.blackbox_alb_name}"
+    prefix  = "alb/${data.aws_caller_identity.current.account_id}/${local.blackbox_alb_name}"
   }
 
   enable_deletion_protection = (lower(var.tags["is-production"]) == "true") ? true : false

--- a/modules/monitoring_cluster_ecs/cloudwatch_exporter.tf
+++ b/modules/monitoring_cluster_ecs/cloudwatch_exporter.tf
@@ -52,7 +52,7 @@ resource "aws_alb" "prometheus_cloudwatch_exporter_alb" {
   access_logs {
     bucket  = var.logging_bucket_name
     enabled = true
-    prefix  = "alb/AWSLogs/${data.aws_caller_identity.current.account_id}/${local.cloudwatch_alb_name}"
+    prefix  = "alb/${data.aws_caller_identity.current.account_id}/${local.cloudwatch_alb_name}"
   }
 
   enable_deletion_protection = (lower(var.tags["is-production"]) == "true") ? true : false

--- a/modules/monitoring_cluster_ecs/grafana.tf
+++ b/modules/monitoring_cluster_ecs/grafana.tf
@@ -200,7 +200,7 @@ resource "aws_alb" "grafana_alb" {
   access_logs {
     bucket  = var.logging_bucket_name
     enabled = true
-    prefix  = "alb/AWSLogs/${data.aws_caller_identity.current.account_id}/${local.grafana_alb_name}"
+    prefix  = "alb/${data.aws_caller_identity.current.account_id}/${local.grafana_alb_name}"
   }
 
   enable_deletion_protection = (lower(var.tags["is-production"]) == "true") ? true : false

--- a/modules/monitoring_cluster_ecs/logstash.tf
+++ b/modules/monitoring_cluster_ecs/logstash.tf
@@ -52,7 +52,7 @@ resource "aws_alb" "logstash_alb" {
   access_logs {
     bucket  = var.logging_bucket_name
     enabled = true
-    prefix  = "alb/AWSLogs/${data.aws_caller_identity.current.account_id}/${local.cloudwatch_alb_name}"
+    prefix  = "alb/${data.aws_caller_identity.current.account_id}/${local.cloudwatch_alb_name}"
   }
 
   enable_deletion_protection = (lower(var.tags["is-production"]) == "true") ? true : false

--- a/modules/monitoring_cluster_ecs/prometheus.tf
+++ b/modules/monitoring_cluster_ecs/prometheus.tf
@@ -97,7 +97,7 @@ resource "aws_alb" "prometheus_alb" {
   access_logs {
     bucket  = var.logging_bucket_name
     enabled = true
-    prefix  = "alb/AWSLogs/${data.aws_caller_identity.current.account_id}/${local.prometheus_alb_name}"
+    prefix  = "alb/${data.aws_caller_identity.current.account_id}/${local.prometheus_alb_name}"
   }
 
   enable_deletion_protection = (lower(var.tags["is-production"]) == "true") ? true : false
@@ -119,7 +119,7 @@ resource "aws_alb" "prometheus_alert_manager_alb" {
   access_logs {
     bucket  = var.logging_bucket_name
     enabled = true
-    prefix  = "alb/AWSLogs/${data.aws_caller_identity.current.account_id}/${local.prometheus_alert_alb_name}"
+    prefix  = "alb/${data.aws_caller_identity.current.account_id}/${local.prometheus_alert_alb_name}"
   }
 
   enable_deletion_protection = (lower(var.tags["is-production"]) == "true") ? true : false

--- a/modules/nginx_auth_proxy_ecs/load_balancer.tf
+++ b/modules/nginx_auth_proxy_ecs/load_balancer.tf
@@ -12,7 +12,7 @@ resource "aws_alb" "auth_proxy_alb" {
   access_logs {
     bucket  = var.logging_bucket_name
     enabled = true
-    prefix  = "alb/AWSLogs/${data.aws_caller_identity.current.account_id}/${local.alb_name}"
+    prefix  = "alb/${data.aws_caller_identity.current.account_id}/${local.alb_name}"
   }
 
   enable_deletion_protection = (lower(var.tags["is-production"]) == "true") ? true : false

--- a/modules/nginx_auth_proxy_ecs/main.tf
+++ b/modules/nginx_auth_proxy_ecs/main.tf
@@ -14,7 +14,7 @@ resource "aws_ssm_parameter" "nginx_auth_proxy_deploy_tag" {
 }
 
 //module "nginx_auth_proxy_alb" {
-//  source = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb"
+//  source = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb?ref=remove-AWSLogs-s3-prefix"
 //
 //  alb_security_groups = [
 //    data.aws_security_group.nginx_auth_proxy_alb.id

--- a/modules/pncemulator_ecs_task/main.tf
+++ b/modules/pncemulator_ecs_task/main.tf
@@ -1,5 +1,5 @@
 module "pncemulator_ecs_alb" {
-  source              = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb"
+  source              = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb?ref=remove-AWSLogs-s3-prefix"
   load_balancer_type  = "network"
   service_subnets     = var.service_subnets
   alb_name            = local.alb_name

--- a/modules/postfix_vpc/postfix.tf
+++ b/modules/postfix_vpc/postfix.tf
@@ -61,7 +61,7 @@ resource "aws_cloudwatch_log_group" "postfix_log_group" {
 }
 
 module "postfix_nlb" {
-  source             = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb"
+  source             = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb?ref=remove-AWSLogs-s3-prefix"
   load_balancer_type = "network"
   vpc_id             = module.postfix_vpc.vpc_id
 

--- a/modules/s3_web_proxy/main.tf
+++ b/modules/s3_web_proxy/main.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_log_group" "ecs_log_group" {
 }
 
 module "s3_web_proxy_ecs_alb" {
-  source = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb"
+  source = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb?ref=remove-AWSLogs-s3-prefix"
   alb_security_groups = [
     aws_security_group.s3_web_proxy_alb.id
   ]

--- a/modules/scanning_results_ecs/main.tf
+++ b/modules/scanning_results_ecs/main.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_log_group" "ecs_log_group" {
 }
 
 module "scanning_portal_ecs_alb" {
-  source = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb"
+  source = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb?ref=remove-AWSLogs-s3-prefix"
   alb_security_groups = [
     aws_security_group.scanning_portal_alb.id
   ]

--- a/modules/user_service_ecs/main.tf
+++ b/modules/user_service_ecs/main.tf
@@ -14,7 +14,7 @@ resource "aws_ssm_parameter" "user_service_deploy_tag" {
 }
 
 module "user_service_alb" {
-  source = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb"
+  source = "github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb?ref=remove-AWSLogs-s3-prefix"
 
   alb_security_groups = [
     data.aws_security_group.user_service_alb.id


### PR DESCRIPTION
This has recently been disallowed by AWS, see the documentation change here
https://github.com/awsdocs/elb-application-load-balancers-user-guide/commit/f633fe6264b518414438fbbf0783da7663ea1d6f#diff-450a40b5fec9ee21052ee32d91879b108eb8b07346301d98c4d10e1f42f35057R31

Currently, new terraform deploys of application load balancers fail with:
```
Error: failure configuring LB attributes: ValidationError: The value of 'access_logs.s3.prefix' cannot contain 'AWSLogs'
	status code: 400, request id: <request_id>

  with module.portal_ecs_cluster.module.audit_logging_portal_ecs_alb.aws_alb.alb,
  on .terraform/modules/portal_ecs_cluster.audit_logging_portal_ecs_alb/modules/ecs_cluster_alb/main.tf line 1, in resource "aws_alb" "alb":
   1: resource "aws_alb" "alb" {
```

This is complicated by the fact that our IAM policies allowing services to write their logs to the aws logs s3 bucket is managed by the `aws-logs` module, which has logic to ensure that `AWSLogs` appears in s3 path specified in IAM policies, and this causes the alb to fail to deploy :( https://github.com/trussworks/terraform-aws-logs/blob/65ca847c9544b96fcf7e61fbfc74af1eb21090d9/main.tf#L116

For now this PR is not in a working state, and we will need to find a workaround to fix the S3 path in the bucket policy managed by the aws-logs module, or find an alternative to using the module