### PR TITLE
chore: 🤖 outbound sgr needed for s3 vpc endpoint to pull ecr

### DIFF
--- a/modules/ui_ecs/README.md
+++ b/modules/ui_ecs/README.md
@@ -28,10 +28,12 @@
 |------|------|
 | [aws_route53_record.ui](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
 | [aws_security_group_rule.allow_alb_to_containers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.allow_containers_s3_outbound](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.allow_ecs_to_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.allow_https_from_alb_into_containers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.allow_https_from_ecs_into_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
 | [aws_ssm_parameter.ui_deploy_tag](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
+| [aws_ec2_managed_prefix_list.s3](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ec2_managed_prefix_list) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
 | [aws_route53_zone.public_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/route53_zone) | data source |
 | [aws_security_group.ui_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |

--- a/modules/ui_ecs/data.tf
+++ b/modules/ui_ecs/data.tf
@@ -24,3 +24,7 @@ data "template_file" "ui_fargate" {
     region            = data.aws_region.current.name
   }
 }
+
+data "aws_ec2_managed_prefix_list" "s3" {
+  name = "com.amazonaws.${data.aws_region.current.name}.s3"
+}

--- a/modules/ui_ecs/security_groups.tf
+++ b/modules/ui_ecs/security_groups.tf
@@ -45,3 +45,15 @@ resource "aws_security_group_rule" "allow_https_from_ecs_into_alb" {
 
   source_security_group_id = data.aws_security_group.ui_ecs.id
 }
+
+resource "aws_security_group_rule" "allow_containers_s3_outbound" {
+  description = "Allow s3 outbound from containers to our VPC, needed to pull from ecr"
+
+  from_port         = 443
+  protocol          = "tcp"
+  to_port           = 443
+  security_group_id = data.aws_security_group.ui_ecs.id
+  type              = "egress"
+
+  prefix_list_ids = [data.aws_ec2_managed_prefix_list.s3.id]
+}


### PR DESCRIPTION
We can't pull the image from ecr on ptl accounts without outbound access to s3, which is where ecr stores image layers.