### PR TITLE
chore: 🤖 allow slack lambda to be created in parent ptl account

### DIFF
--- a/modules/lambda_slack_webhook/locals.tf
+++ b/modules/lambda_slack_webhook/locals.tf
@@ -1,3 +1,3 @@
 locals {
-  is_production = (terraform.workspace == "production") ? true : false
+  is_production = (terraform.workspace == "production" || terraform.workspace == "pathtolive-ci") ? true : false
 }


### PR DESCRIPTION
- Add the pathtolive parent to the whitelist to deploy the slack lambda