### PR TITLE
chore: 🤖 keep latest 30 images and don't delete by age

### DIFF
--- a/modules/aws_ecr_repositories/policies/application_image_ecr_lifecycle_policy.json
+++ b/modules/aws_ecr_repositories/policies/application_image_ecr_lifecycle_policy.json
@@ -11,19 +11,6 @@
       "action": {
         "type": "expire"
       }
-    },
-    {
-      "rulePriority": 10,
-      "description": "Expire images older than 21 days",
-      "selection": {
-        "tagStatus": "any",
-        "countType": "sinceImagePushed",
-        "countUnit": "days",
-        "countNumber": 21
-      },
-      "action": {
-        "type": "expire"
-      }
     }
   ]
 }

--- a/modules/aws_ecr_repositories/policies/builder_image_ecr_lifecycle_policy.json
+++ b/modules/aws_ecr_repositories/policies/builder_image_ecr_lifecycle_policy.json
@@ -2,11 +2,11 @@
   "rules": [
     {
       "rulePriority": 1,
-      "description": "Keep last 5 images only",
+      "description": "Keep last 30 images only",
       "selection": {
         "tagStatus": "any",
         "countType": "imageCountMoreThan",
-        "countNumber": 5
+        "countNumber": 30
       },
       "action": {
         "type": "expire"

--- a/modules/aws_ecr_repositories/policies/helper_image_ecr_lifecycle_policy.json
+++ b/modules/aws_ecr_repositories/policies/helper_image_ecr_lifecycle_policy.json
@@ -2,11 +2,11 @@
   "rules": [
     {
       "rulePriority": 10,
-      "description": "Expire images older than 21 days",
+      "description": "Keep last 30 images only",
       "selection": {
         "tagStatus": "any",
         "countType": "imageCountMoreThan",
-        "countNumber": 2
+        "countNumber": 30
       },
       "action": {
         "type": "expire"


### PR DESCRIPTION
Previously ecr repos were being left with no images in, this happened in repos which contained images that were built infrequently. This would cause annoying bugs and slow down dev work until you had to recreate the image and push it up.

Now we just keep the latest 30 images.