### PR TITLE
Bicaws 1910 - Use smaller Grafana instances

### DIFF
--- a/modules/codebuild_monitoring/db.tf
+++ b/modules/codebuild_monitoring/db.tf
@@ -127,7 +127,7 @@ resource "aws_rds_cluster" "grafana_db" {
 }
 
 resource "aws_rds_cluster_instance" "grafana_db_instance" {
-  count = 3
+  count = var.grafana_db_instance_count
 
   cluster_identifier   = aws_rds_cluster.grafana_db.id
   instance_class       = var.grafana_db_instance_class

--- a/modules/codebuild_monitoring/variables.tf
+++ b/modules/codebuild_monitoring/variables.tf
@@ -58,6 +58,12 @@ variable "grafana_db_instance_class" {
   type        = string
 }
 
+variable "grafana_db_instance_count" {
+  description = "The number of DB instance we are using for Grafana"
+  default     = 3
+  type        = number
+}
+
 variable "using_smtp_service" {
   description = "Are we using the CJSM smtp service"
   type        = bool

--- a/modules/codebuild_monitoring/variables.tf
+++ b/modules/codebuild_monitoring/variables.tf
@@ -54,7 +54,7 @@ variable "remote_exec_enabled" {
 
 variable "grafana_db_instance_class" {
   description = "The class of DB instance we are using for Grafana"
-  default     = "db.t3.medium"
+  default     = "db.t3.small"
   type        = string
 }
 

--- a/modules/monitoring_cluster_ecs/grafana.tf
+++ b/modules/monitoring_cluster_ecs/grafana.tf
@@ -127,7 +127,7 @@ resource "aws_rds_cluster" "grafana_db" {
 }
 
 resource "aws_rds_cluster_instance" "grafana_db_instance" {
-  count = 3
+  count = var.grafana_db_instance_count
 
   cluster_identifier   = aws_rds_cluster.grafana_db.id
   instance_class       = var.grafana_db_instance_class

--- a/modules/monitoring_cluster_ecs/variables.tf
+++ b/modules/monitoring_cluster_ecs/variables.tf
@@ -183,6 +183,12 @@ variable "grafana_db_instance_class" {
   type        = string
 }
 
+variable "grafana_db_instance_count" {
+  description = "The number of DB instance we are using for Grafana"
+  default     = 3
+  type        = number
+}
+
 variable "using_smtp_service" {
   description = "Are we using the CJSM smtp service"
   type        = bool

--- a/modules/monitoring_cluster_ecs/variables.tf
+++ b/modules/monitoring_cluster_ecs/variables.tf
@@ -179,7 +179,7 @@ variable "prometheus_blackbox_exporter_image" {
 
 variable "grafana_db_instance_class" {
   description = "The class of DB instance we are using for Grafana"
-  default     = "db.t3.medium"
+  default     = "db.t3.small"
   type        = string
 }
 


### PR DESCRIPTION
### Context
We want to reduce the cost of running the cluster and code build monitoring.
Running `db.t3.small` RDS instances should be sufficient for Grafana while it costs half as much `db.t3.medium` costs

### Changes
- Change the default grafana DB instance size to `db.t3.small`
- Allow changing the number of running instances using variables 
