### PR TITLE
Update the default grafana DB instance class

### DIFF
--- a/modules/codebuild_monitoring/variables.tf
+++ b/modules/codebuild_monitoring/variables.tf
@@ -54,7 +54,7 @@ variable "remote_exec_enabled" {
 
 variable "grafana_db_instance_class" {
   description = "The class of DB instance we are using for Grafana"
-  default     = "db.t3.small"
+  default     = "db.t4g.medium"
   type        = string
 }
 

--- a/modules/monitoring_cluster_ecs/variables.tf
+++ b/modules/monitoring_cluster_ecs/variables.tf
@@ -179,7 +179,7 @@ variable "prometheus_blackbox_exporter_image" {
 
 variable "grafana_db_instance_class" {
   description = "The class of DB instance we are using for Grafana"
-  default     = "db.t3.small"
+  default     = "db.t4g.medium"
   type        = string
 }
 


### PR DESCRIPTION
The currently set instance is not compatible with Engine=aurora-postgresql, EngineVersion=13.4