### PR TITLE
set up lifecycle policy for audit-logging/

### DIFF
--- a/modules/amazonmq/README.md
+++ b/modules/amazonmq/README.md
@@ -3,20 +3,21 @@
 Module to create amazon mq cluster
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | = 3.0.1 |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
+| <a name="requirement_random"></a> [random](#requirement_random)          | = 3.0.1  |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | = 3.75.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | = 3.0.1 |
+| Name                                                      | Version  |
+| --------------------------------------------------------- | -------- |
+| <a name="provider_aws"></a> [aws](#provider_aws)          | = 3.75.2 |
+| <a name="provider_random"></a> [random](#provider_random) | = 3.0.1  |
 
 ## Modules
 
@@ -24,56 +25,57 @@ No modules.
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_cloudwatch_log_resource_policy.amazon-mq-log-publishing-policy](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_log_resource_policy) | resource |
-| [aws_kms_alias.amq](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias) | resource |
-| [aws_kms_key.amq_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key) | resource |
-| [aws_mq_broker.amq](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/mq_broker) | resource |
-| [aws_mq_configuration.amq](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/mq_configuration) | resource |
-| [aws_route53_record.mq](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_security_group_rule.amq_allow_all_egress_to_was_backend](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.amq_allow_all_egress_to_was_web](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.amq_allow_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.amq_allow_queue_vpc_ingress_openwire](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.amq_allow_queue_vpc_ingress_stomp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.was_backend_ingress_to_amq_openwire](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.was_backendingress_to_amq_stomp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.was_ui_ingress_to_amq_stomp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.was_web_ingress_to_amq_openwire](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.was_web_ingress_to_amq_stomp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_ssm_parameter.amq_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [random_password.amq](https://registry.terraform.io/providers/hashicorp/random/3.0.1/docs/resources/password) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy_document.amazon_mq_log_publishing_policy](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/iam_policy_document) | data source |
-| [aws_route53_zone.cjse_dot_org](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/route53_zone) | data source |
-| [aws_security_group.amq](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.bichard7_backend](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.bichard7_ui](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.bichard7_web](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
+| Name                                                                                                                                                                             | Type        |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_cloudwatch_log_resource_policy.amazon-mq-log-publishing-policy](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_log_resource_policy) | resource    |
+| [aws_kms_alias.amq](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias)                                                                       | resource    |
+| [aws_kms_key.amq_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key)                                                            | resource    |
+| [aws_mq_broker.amq](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/mq_broker)                                                                       | resource    |
+| [aws_mq_configuration.amq](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/mq_configuration)                                                         | resource    |
+| [aws_route53_record.mq](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                                                              | resource    |
+| [aws_security_group_rule.amq_allow_all_egress_to_was_backend](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                   | resource    |
+| [aws_security_group_rule.amq_allow_all_egress_to_was_web](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                       | resource    |
+| [aws_security_group_rule.amq_allow_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                      | resource    |
+| [aws_security_group_rule.amq_allow_queue_vpc_ingress_openwire](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                  | resource    |
+| [aws_security_group_rule.amq_allow_queue_vpc_ingress_stomp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                     | resource    |
+| [aws_security_group_rule.was_backend_ingress_to_amq_openwire](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                   | resource    |
+| [aws_security_group_rule.was_backendingress_to_amq_stomp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                       | resource    |
+| [aws_security_group_rule.was_ui_ingress_to_amq_stomp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                           | resource    |
+| [aws_security_group_rule.was_web_ingress_to_amq_openwire](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                       | resource    |
+| [aws_security_group_rule.was_web_ingress_to_amq_stomp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                          | resource    |
+| [aws_ssm_parameter.amq_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                                      | resource    |
+| [random_password.amq](https://registry.terraform.io/providers/hashicorp/random/3.0.1/docs/resources/password)                                                                    | resource    |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                                    | data source |
+| [aws_iam_policy_document.amazon_mq_log_publishing_policy](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/iam_policy_document)                    | data source |
+| [aws_route53_zone.cjse_dot_org](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/route53_zone)                                                     | data source |
+| [aws_security_group.amq](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                                          | data source |
+| [aws_security_group.bichard7_backend](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                             | data source |
+| [aws_security_group.bichard7_ui](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                                  | data source |
+| [aws_security_group.bichard7_web](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                                 | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_allowed_cidrs"></a> [allowed\_cidrs](#input\_allowed\_cidrs) | The CIDR blocks allowed to connect to Amazon MQ | `list(string)` | n/a | yes |
-| <a name="input_amq_master_username"></a> [amq\_master\_username](#input\_amq\_master\_username) | The master username for the rds instance | `string` | n/a | yes |
-| <a name="input_broker_instance_type"></a> [broker\_instance\_type](#input\_broker\_instance\_type) | The instance type we want to use for our broker | `string` | `"mq.t2.micro"` | no |
-| <a name="input_environment_name"></a> [environment\_name](#input\_environment\_name) | The name of the environment | `string` | n/a | yes |
-| <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | The ID's of the VPC subnets that the RDS cluster instances will be created in | `list(string)` | n/a | yes |
-| <a name="input_private_zone_id"></a> [private\_zone\_id](#input\_private\_zone\_id) | The private hosted zone | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | The tags for the resources | `map(string)` | n/a | yes |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC that the RDS cluster will be created in | `string` | n/a | yes |
+| Name                                                                                          | Description                                                                   | Type           | Default         | Required |
+| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -------------- | --------------- | :------: |
+| <a name="input_allowed_cidrs"></a> [allowed_cidrs](#input_allowed_cidrs)                      | The CIDR blocks allowed to connect to Amazon MQ                               | `list(string)` | n/a             |   yes    |
+| <a name="input_amq_master_username"></a> [amq_master_username](#input_amq_master_username)    | The master username for the rds instance                                      | `string`       | n/a             |   yes    |
+| <a name="input_broker_instance_type"></a> [broker_instance_type](#input_broker_instance_type) | The instance type we want to use for our broker                               | `string`       | `"mq.t2.micro"` |    no    |
+| <a name="input_environment_name"></a> [environment_name](#input_environment_name)             | The name of the environment                                                   | `string`       | n/a             |   yes    |
+| <a name="input_private_subnet_ids"></a> [private_subnet_ids](#input_private_subnet_ids)       | The ID's of the VPC subnets that the RDS cluster instances will be created in | `list(string)` | n/a             |   yes    |
+| <a name="input_private_zone_id"></a> [private_zone_id](#input_private_zone_id)                | The private hosted zone                                                       | `string`       | n/a             |   yes    |
+| <a name="input_tags"></a> [tags](#input_tags)                                                 | The tags for the resources                                                    | `map(string)`  | n/a             |   yes    |
+| <a name="input_vpc_id"></a> [vpc_id](#input_vpc_id)                                           | The ID of the VPC that the RDS cluster will be created in                     | `string`       | n/a             |   yes    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_amq_arn"></a> [amq\_arn](#output\_amq\_arn) | The ARN of the AmazonMQ broker |
-| <a name="output_internal_fqdn"></a> [internal\_fqdn](#output\_internal\_fqdn) | The internal FQDN of our db |
-| <a name="output_messaging_endpoint"></a> [messaging\_endpoint](#output\_messaging\_endpoint) | The messaging endpoint url |
-| <a name="output_openwire_url"></a> [openwire\_url](#output\_openwire\_url) | A generated URL for the ActiveMQ endpoint over the OpenWire protocol |
-| <a name="output_password_arn"></a> [password\_arn](#output\_password\_arn) | The ARN for the password in SSM |
-| <a name="output_password_value"></a> [password\_value](#output\_password\_value) | The value of the MQ password |
-| <a name="output_stomp_url"></a> [stomp\_url](#output\_stomp\_url) | A generated URL for the ActiveMQ endpoint over the Stomp protocol |
+| Name                                                                                      | Description                                                          |
+| ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| <a name="output_amq_arn"></a> [amq_arn](#output_amq_arn)                                  | The ARN of the AmazonMQ broker                                       |
+| <a name="output_internal_fqdn"></a> [internal_fqdn](#output_internal_fqdn)                | The internal FQDN of our db                                          |
+| <a name="output_messaging_endpoint"></a> [messaging_endpoint](#output_messaging_endpoint) | The messaging endpoint url                                           |
+| <a name="output_openwire_url"></a> [openwire_url](#output_openwire_url)                   | A generated URL for the ActiveMQ endpoint over the OpenWire protocol |
+| <a name="output_password_arn"></a> [password_arn](#output_password_arn)                   | The ARN for the password in SSM                                      |
+| <a name="output_password_value"></a> [password_value](#output_password_value)             | The value of the MQ password                                         |
+| <a name="output_stomp_url"></a> [stomp_url](#output_stomp_url)                            | A generated URL for the ActiveMQ endpoint over the Stomp protocol    |
+
 <!-- END_TF_DOCS -->

--- a/modules/amazonmq/README.md
+++ b/modules/amazonmq/README.md
@@ -15,8 +15,8 @@ Module to create amazon mq cluster
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.0.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | = 3.75.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | = 3.0.1 |
 
 ## Modules
 

--- a/modules/codebuild_base_resources/README.md
+++ b/modules/codebuild_base_resources/README.md
@@ -53,6 +53,7 @@ Module to create a set of base resources required for our CD/Codebuild environme
 | [aws_s3_bucket.codebuild_artifact_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.codebuild_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.scanning_results_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.artifact_bucket_lifecycle_audit_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_policy.allow_access_to_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.allow_access_to_scanning_results_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.codebuild_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_policy) | resource |

--- a/modules/codebuild_base_resources/README.md
+++ b/modules/codebuild_base_resources/README.md
@@ -3,135 +3,137 @@
 Module to create a set of base resources required for our CD/Codebuild environment
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_archive"></a> [archive](#requirement\_archive) | = 2.2.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | = 2.2.0 |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
+| <a name="requirement_archive"></a> [archive](#requirement_archive)       | = 2.2.0  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
+| <a name="requirement_template"></a> [template](#requirement_template)    | = 2.2.0  |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.2.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
+| Name                                                            | Version |
+| --------------------------------------------------------------- | ------- |
+| <a name="provider_archive"></a> [archive](#provider_archive)    | 2.2.0   |
+| <a name="provider_aws"></a> [aws](#provider_aws)                | 3.75.2  |
+| <a name="provider_template"></a> [template](#provider_template) | 2.2.0   |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.0.0 |
+| Name                                         | Source                        | Version |
+| -------------------------------------------- | ----------------------------- | ------- |
+| <a name="module_vpc"></a> [vpc](#module_vpc) | terraform-aws-modules/vpc/aws | 3.0.0   |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_dynamodb_table.codebuild_lock_table](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/dynamodb_table) | resource |
-| [aws_iam_policy.allow_ci_ssm_access](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.lambda_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.scanning_lambda_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
-| [aws_iam_role.codebuild_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role) | resource |
-| [aws_iam_role.scanning_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.lambda_logs](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.scanning_lambda_logs](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_user_policy.allow_lock_table_access](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy) | resource |
-| [aws_iam_user_policy_attachment.allow_ci_ssm_access](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy_attachment) | resource |
-| [aws_kms_alias.build_notifications_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias) | resource |
-| [aws_kms_alias.remote_state_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias) | resource |
-| [aws_kms_alias.scanning_notifications_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias) | resource |
-| [aws_kms_key.build_notifications_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key) | resource |
-| [aws_kms_key.codebuild_lock_table](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key) | resource |
-| [aws_kms_key.scanning_notifications_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key) | resource |
-| [aws_lambda_function.codebuild_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function) | resource |
-| [aws_lambda_function.scanning_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function) | resource |
-| [aws_lambda_permission.codebuild_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission) | resource |
-| [aws_lambda_permission.scanning_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission) | resource |
-| [aws_s3_bucket.codebuild_artifact_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.codebuild_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.scanning_results_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_lifecycle_configuration.artifact_bucket_lifecycle_audit_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_lifecycle_configuration) | resource |
-| [aws_s3_bucket_policy.allow_access_to_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_policy.allow_access_to_scanning_results_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_policy.codebuild_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_public_access_block.codebuild_artifact_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_public_access_block.codebuild_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_public_access_block.scanning_results_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_security_group.codebuild_vpc_sg](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group) | resource |
-| [aws_security_group_rule.allow_all_github_git](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_all_github_http](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_all_github_ssh](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_all_github_ssl](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_github_http_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_github_ssl_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_outbound_gpg_server_traffic](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.vpc_to_cb_vpce_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.vpce_to_cb_vpc_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_sns_topic.build_notifications](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic) | resource |
-| [aws_sns_topic.scanning_notifications](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic) | resource |
-| [aws_sns_topic_policy.default](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic_policy) | resource |
-| [aws_sns_topic_policy.scanning_notifications](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic_policy) | resource |
-| [aws_sns_topic_subscription.build_notice_subscription](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic_subscription) | resource |
-| [aws_sns_topic_subscription.scanning_notice_subscription](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic_subscription) | resource |
-| [aws_ssm_parameter.slack_webhook](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_vpc_endpoint.codepipeline_vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/vpc_endpoint) | resource |
-| [archive_file.codebuild_notification](https://registry.terraform.io/providers/hashicorp/archive/2.2.0/docs/data-sources/file) | data source |
-| [archive_file.scanning_notification](https://registry.terraform.io/providers/hashicorp/archive/2.2.0/docs/data-sources/file) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_iam_user.ci_user](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/iam_user) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
-| [aws_ssm_parameter.slack_webhook](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter) | data source |
-| [template_file.allow_access_to_scanning_results_bucket](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.allow_ci_slack_ssm](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.allow_codestar_kms](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.allow_dynamodb_lock_table_access](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.allow_scanning_sns_publish_policy](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.allow_sns_publish_policy](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.child_accounts_cmk_access_template](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.codebuild_bucket_policy](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.codebuild_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.scanning_webhook_source](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.webhook_source](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
+| Name                                                                                                                                                                                           | Type        |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_dynamodb_table.codebuild_lock_table](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/dynamodb_table)                                                          | resource    |
+| [aws_iam_policy.allow_ci_ssm_access](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)                                                                   | resource    |
+| [aws_iam_policy.lambda_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)                                                                        | resource    |
+| [aws_iam_policy.scanning_lambda_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)                                                               | resource    |
+| [aws_iam_role.codebuild_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role)                                                                    | resource    |
+| [aws_iam_role.scanning_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role)                                                                     | resource    |
+| [aws_iam_role_policy_attachment.lambda_logs](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment)                                           | resource    |
+| [aws_iam_role_policy_attachment.scanning_lambda_logs](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment)                                  | resource    |
+| [aws_iam_user_policy.allow_lock_table_access](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy)                                                     | resource    |
+| [aws_iam_user_policy_attachment.allow_ci_ssm_access](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_user_policy_attachment)                                   | resource    |
+| [aws_kms_alias.build_notifications_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias)                                                           | resource    |
+| [aws_kms_alias.remote_state_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias)                                                                  | resource    |
+| [aws_kms_alias.scanning_notifications_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias)                                                        | resource    |
+| [aws_kms_key.build_notifications_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key)                                                                     | resource    |
+| [aws_kms_key.codebuild_lock_table](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key)                                                                        | resource    |
+| [aws_kms_key.scanning_notifications_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key)                                                                  | resource    |
+| [aws_lambda_function.codebuild_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function)                                                      | resource    |
+| [aws_lambda_function.scanning_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function)                                                       | resource    |
+| [aws_lambda_permission.codebuild_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission)                                                  | resource    |
+| [aws_lambda_permission.scanning_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission)                                                   | resource    |
+| [aws_s3_bucket.codebuild_artifact_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket)                                                               | resource    |
+| [aws_s3_bucket.codebuild_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket)                                                              | resource    |
+| [aws_s3_bucket.scanning_results_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket)                                                                 | resource    |
+| [aws_s3_bucket_lifecycle_configuration.artifact_bucket_lifecycle_audit_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_lifecycle_configuration) | resource    |
+| [aws_s3_bucket_policy.allow_access_to_codebuild_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_policy)                                          | resource    |
+| [aws_s3_bucket_policy.allow_access_to_scanning_results_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_policy)                                   | resource    |
+| [aws_s3_bucket_policy.codebuild_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_policy)                                                | resource    |
+| [aws_s3_bucket_public_access_block.codebuild_artifact_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_public_access_block)                       | resource    |
+| [aws_s3_bucket_public_access_block.codebuild_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_public_access_block)                      | resource    |
+| [aws_s3_bucket_public_access_block.scanning_results_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_public_access_block)                         | resource    |
+| [aws_security_group.codebuild_vpc_sg](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group)                                                              | resource    |
+| [aws_security_group_rule.allow_all_github_git](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                                | resource    |
+| [aws_security_group_rule.allow_all_github_http](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                               | resource    |
+| [aws_security_group_rule.allow_all_github_ssh](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                                | resource    |
+| [aws_security_group_rule.allow_all_github_ssl](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                                | resource    |
+| [aws_security_group_rule.allow_github_http_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                           | resource    |
+| [aws_security_group_rule.allow_github_ssl_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                            | resource    |
+| [aws_security_group_rule.allow_outbound_gpg_server_traffic](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                   | resource    |
+| [aws_security_group_rule.vpc_to_cb_vpce_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                               | resource    |
+| [aws_security_group_rule.vpce_to_cb_vpc_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                              | resource    |
+| [aws_sns_topic.build_notifications](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic)                                                                     | resource    |
+| [aws_sns_topic.scanning_notifications](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic)                                                                  | resource    |
+| [aws_sns_topic_policy.default](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic_policy)                                                                   | resource    |
+| [aws_sns_topic_policy.scanning_notifications](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic_policy)                                                    | resource    |
+| [aws_sns_topic_subscription.build_notice_subscription](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic_subscription)                                     | resource    |
+| [aws_sns_topic_subscription.scanning_notice_subscription](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic_subscription)                                  | resource    |
+| [aws_ssm_parameter.slack_webhook](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                                                   | resource    |
+| [aws_vpc_endpoint.codepipeline_vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/vpc_endpoint)                                                         | resource    |
+| [archive_file.codebuild_notification](https://registry.terraform.io/providers/hashicorp/archive/2.2.0/docs/data-sources/file)                                                                  | data source |
+| [archive_file.scanning_notification](https://registry.terraform.io/providers/hashicorp/archive/2.2.0/docs/data-sources/file)                                                                   | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                                                  | data source |
+| [aws_iam_user.ci_user](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/iam_user)                                                                                | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                                                                    | data source |
+| [aws_ssm_parameter.slack_webhook](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter)                                                                | data source |
+| [template_file.allow_access_to_scanning_results_bucket](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                               | data source |
+| [template_file.allow_ci_slack_ssm](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                                    | data source |
+| [template_file.allow_codestar_kms](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                                    | data source |
+| [template_file.allow_dynamodb_lock_table_access](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                      | data source |
+| [template_file.allow_scanning_sns_publish_policy](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                     | data source |
+| [template_file.allow_sns_publish_policy](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                              | data source |
+| [template_file.child_accounts_cmk_access_template](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                    | data source |
+| [template_file.codebuild_bucket_policy](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                               | data source |
+| [template_file.codebuild_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                            | data source |
+| [template_file.scanning_webhook_source](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                               | data source |
+| [template_file.webhook_source](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                                        | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_allow_accounts"></a> [allow\_accounts](#input\_allow\_accounts) | A list of account ids allowed to access our s3 resource | `list(string)` | n/a | yes |
-| <a name="input_aws_logs_bucket"></a> [aws\_logs\_bucket](#input\_aws\_logs\_bucket) | Our account logging bucket for s3 logs | `string` | n/a | yes |
-| <a name="input_channel_name"></a> [channel\_name](#input\_channel\_name) | Our slack channel for notifications | `string` | `"moj-cjse-bichard"` | no |
-| <a name="input_name"></a> [name](#input\_name) | Our resource name | `string` | n/a | yes |
-| <a name="input_notifications_channel_name"></a> [notifications\_channel\_name](#input\_notifications\_channel\_name) | Our slack channel for build notifications | `string` | `"moj-cjse-bichard-notifications"` | no |
-| <a name="input_slack_webhook"></a> [slack\_webhook](#input\_slack\_webhook) | Our webhook for slack | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of resource tags | `map(string)` | n/a | yes |
-| <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | Our cidr block to apply to this vpc | `string` | `null` | no |
+| Name                                                                                                            | Description                                             | Type           | Default                            | Required |
+| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | -------------- | ---------------------------------- | :------: |
+| <a name="input_allow_accounts"></a> [allow_accounts](#input_allow_accounts)                                     | A list of account ids allowed to access our s3 resource | `list(string)` | n/a                                |   yes    |
+| <a name="input_aws_logs_bucket"></a> [aws_logs_bucket](#input_aws_logs_bucket)                                  | Our account logging bucket for s3 logs                  | `string`       | n/a                                |   yes    |
+| <a name="input_channel_name"></a> [channel_name](#input_channel_name)                                           | Our slack channel for notifications                     | `string`       | `"moj-cjse-bichard"`               |    no    |
+| <a name="input_name"></a> [name](#input_name)                                                                   | Our resource name                                       | `string`       | n/a                                |   yes    |
+| <a name="input_notifications_channel_name"></a> [notifications_channel_name](#input_notifications_channel_name) | Our slack channel for build notifications               | `string`       | `"moj-cjse-bichard-notifications"` |    no    |
+| <a name="input_slack_webhook"></a> [slack_webhook](#input_slack_webhook)                                        | Our webhook for slack                                   | `string`       | n/a                                |   yes    |
+| <a name="input_tags"></a> [tags](#input_tags)                                                                   | A map of resource tags                                  | `map(string)`  | n/a                                |   yes    |
+| <a name="input_vpc_cidr_block"></a> [vpc_cidr_block](#input_vpc_cidr_block)                                     | Our cidr block to apply to this vpc                     | `string`       | `null`                             |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_codebuild_cidr_block"></a> [codebuild\_cidr\_block](#output\_codebuild\_cidr\_block) | Our CIDR block for codebuild |
-| <a name="output_codebuild_nat_gateway_ids"></a> [codebuild\_nat\_gateway\_ids](#output\_codebuild\_nat\_gateway\_ids) | The nat gateway ids for our public subnets |
-| <a name="output_codebuild_private_cidr_blocks"></a> [codebuild\_private\_cidr\_blocks](#output\_codebuild\_private\_cidr\_blocks) | A list of private cidr blocks |
-| <a name="output_codebuild_private_cidrs"></a> [codebuild\_private\_cidrs](#output\_codebuild\_private\_cidrs) | The internal cidrs for our codebuild vpc |
-| <a name="output_codebuild_private_subnet_ids"></a> [codebuild\_private\_subnet\_ids](#output\_codebuild\_private\_subnet\_ids) | A list of private subnet ids |
-| <a name="output_codebuild_public_cidr_blocks"></a> [codebuild\_public\_cidr\_blocks](#output\_codebuild\_public\_cidr\_blocks) | A list of public cidr blocks |
-| <a name="output_codebuild_public_cidrs"></a> [codebuild\_public\_cidrs](#output\_codebuild\_public\_cidrs) | The external cidrs for our codebuild vpc |
-| <a name="output_codebuild_public_subnet_ids"></a> [codebuild\_public\_subnet\_ids](#output\_codebuild\_public\_subnet\_ids) | A list of public subnet ids |
-| <a name="output_codebuild_security_group_id"></a> [codebuild\_security\_group\_id](#output\_codebuild\_security\_group\_id) | The allowed security group id for our codebuild\_vpc |
-| <a name="output_codebuild_subnet_ids"></a> [codebuild\_subnet\_ids](#output\_codebuild\_subnet\_ids) | A list of private subnet ids |
-| <a name="output_codebuild_vpc_config_block"></a> [codebuild\_vpc\_config\_block](#output\_codebuild\_vpc\_config\_block) | A preformed config block to pass to codebuild |
-| <a name="output_codebuild_vpc_id"></a> [codebuild\_vpc\_id](#output\_codebuild\_vpc\_id) | The vpc id for our codebuild jobs |
-| <a name="output_codepipeline_bucket"></a> [codepipeline\_bucket](#output\_codepipeline\_bucket) | The name of our bucket |
-| <a name="output_codepipeline_bucket_arn"></a> [codepipeline\_bucket\_arn](#output\_codepipeline\_bucket\_arn) | The arn of our bucket |
-| <a name="output_concurrency_dynamo_db_table"></a> [concurrency\_dynamo\_db\_table](#output\_concurrency\_dynamo\_db\_table) | The dynamotable we are going to use for concurrency locks |
-| <a name="output_notifications_arn"></a> [notifications\_arn](#output\_notifications\_arn) | The arn of our sns topic |
-| <a name="output_notifications_kms_key_arn"></a> [notifications\_kms\_key\_arn](#output\_notifications\_kms\_key\_arn) | The notifications KMS key |
-| <a name="output_notifications_slack_webhook_path"></a> [notifications\_slack\_webhook\_path](#output\_notifications\_slack\_webhook\_path) | The ssm path for our slack webhook |
-| <a name="output_scanning_notifications_arn"></a> [scanning\_notifications\_arn](#output\_scanning\_notifications\_arn) | The arn of our scanning sns topic |
-| <a name="output_scanning_notifications_kms_key_arn"></a> [scanning\_notifications\_kms\_key\_arn](#output\_scanning\_notifications\_kms\_key\_arn) | The scanning notifications KMS key |
-| <a name="output_scanning_results_bucket"></a> [scanning\_results\_bucket](#output\_scanning\_results\_bucket) | The name of our scanning results bucket |
+| Name                                                                                                                                      | Description                                               |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| <a name="output_codebuild_cidr_block"></a> [codebuild_cidr_block](#output_codebuild_cidr_block)                                           | Our CIDR block for codebuild                              |
+| <a name="output_codebuild_nat_gateway_ids"></a> [codebuild_nat_gateway_ids](#output_codebuild_nat_gateway_ids)                            | The nat gateway ids for our public subnets                |
+| <a name="output_codebuild_private_cidr_blocks"></a> [codebuild_private_cidr_blocks](#output_codebuild_private_cidr_blocks)                | A list of private cidr blocks                             |
+| <a name="output_codebuild_private_cidrs"></a> [codebuild_private_cidrs](#output_codebuild_private_cidrs)                                  | The internal cidrs for our codebuild vpc                  |
+| <a name="output_codebuild_private_subnet_ids"></a> [codebuild_private_subnet_ids](#output_codebuild_private_subnet_ids)                   | A list of private subnet ids                              |
+| <a name="output_codebuild_public_cidr_blocks"></a> [codebuild_public_cidr_blocks](#output_codebuild_public_cidr_blocks)                   | A list of public cidr blocks                              |
+| <a name="output_codebuild_public_cidrs"></a> [codebuild_public_cidrs](#output_codebuild_public_cidrs)                                     | The external cidrs for our codebuild vpc                  |
+| <a name="output_codebuild_public_subnet_ids"></a> [codebuild_public_subnet_ids](#output_codebuild_public_subnet_ids)                      | A list of public subnet ids                               |
+| <a name="output_codebuild_security_group_id"></a> [codebuild_security_group_id](#output_codebuild_security_group_id)                      | The allowed security group id for our codebuild_vpc       |
+| <a name="output_codebuild_subnet_ids"></a> [codebuild_subnet_ids](#output_codebuild_subnet_ids)                                           | A list of private subnet ids                              |
+| <a name="output_codebuild_vpc_config_block"></a> [codebuild_vpc_config_block](#output_codebuild_vpc_config_block)                         | A preformed config block to pass to codebuild             |
+| <a name="output_codebuild_vpc_id"></a> [codebuild_vpc_id](#output_codebuild_vpc_id)                                                       | The vpc id for our codebuild jobs                         |
+| <a name="output_codepipeline_bucket"></a> [codepipeline_bucket](#output_codepipeline_bucket)                                              | The name of our bucket                                    |
+| <a name="output_codepipeline_bucket_arn"></a> [codepipeline_bucket_arn](#output_codepipeline_bucket_arn)                                  | The arn of our bucket                                     |
+| <a name="output_concurrency_dynamo_db_table"></a> [concurrency_dynamo_db_table](#output_concurrency_dynamo_db_table)                      | The dynamotable we are going to use for concurrency locks |
+| <a name="output_notifications_arn"></a> [notifications_arn](#output_notifications_arn)                                                    | The arn of our sns topic                                  |
+| <a name="output_notifications_kms_key_arn"></a> [notifications_kms_key_arn](#output_notifications_kms_key_arn)                            | The notifications KMS key                                 |
+| <a name="output_notifications_slack_webhook_path"></a> [notifications_slack_webhook_path](#output_notifications_slack_webhook_path)       | The ssm path for our slack webhook                        |
+| <a name="output_scanning_notifications_arn"></a> [scanning_notifications_arn](#output_scanning_notifications_arn)                         | The arn of our scanning sns topic                         |
+| <a name="output_scanning_notifications_kms_key_arn"></a> [scanning_notifications_kms_key_arn](#output_scanning_notifications_kms_key_arn) | The scanning notifications KMS key                        |
+| <a name="output_scanning_results_bucket"></a> [scanning_results_bucket](#output_scanning_results_bucket)                                  | The name of our scanning results bucket                   |
+
 <!-- END_TF_DOCS -->

--- a/modules/codebuild_base_resources/main.tf
+++ b/modules/codebuild_base_resources/main.tf
@@ -24,6 +24,30 @@ resource "aws_s3_bucket" "codebuild_artifact_bucket" {
   tags = var.tags
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "artifact_bucket_lifecycle_audit_logging" {
+  bucket = aws_s3_bucket.codebuild_artifact_bucket.id
+
+  rule {
+    id = "audit_log_clean_up"
+
+    expiration {
+          days = 90
+        }
+
+    filter {
+      and {
+        prefix = "audit_logging/"
+        tags = {
+          rule = "audit_log_clean_up"
+          autoclean = "true"
+        }
+      }
+    }
+
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "codebuild_artifact_bucket" {
   bucket = aws_s3_bucket.codebuild_artifact_bucket.bucket
 

--- a/modules/codebuild_base_resources/main.tf
+++ b/modules/codebuild_base_resources/main.tf
@@ -31,14 +31,14 @@ resource "aws_s3_bucket_lifecycle_configuration" "artifact_bucket_lifecycle_audi
     id = "audit_log_clean_up"
 
     expiration {
-          days = 90
-        }
+      days = 90
+    }
 
     filter {
       and {
         prefix = "audit_logging/"
         tags = {
-          rule = "audit_log_clean_up"
+          rule      = "audit_log_clean_up"
           autoclean = "true"
         }
       }

--- a/modules/codebuild_monitoring/README.md
+++ b/modules/codebuild_monitoring/README.md
@@ -24,7 +24,7 @@ Provisions a monitoring cluster with the following components
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.2.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
 | <a name="provider_grafana"></a> [grafana](#provider\_grafana) | 1.19.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 | <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.7.2 |
 

--- a/modules/codebuild_monitoring/README.md
+++ b/modules/codebuild_monitoring/README.md
@@ -5,129 +5,131 @@ Provisions a monitoring cluster with the following components
 - Grafana
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_archive"></a> [archive](#requirement\_archive) | = 2.2.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
-| <a name="requirement_grafana"></a> [grafana](#requirement\_grafana) | 1.19.0 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | = 2.0.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | = 2.2.0 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | 0.7.2 |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
+| <a name="requirement_archive"></a> [archive](#requirement_archive)       | = 2.2.0  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
+| <a name="requirement_grafana"></a> [grafana](#requirement_grafana)       | 1.19.0   |
+| <a name="requirement_local"></a> [local](#requirement_local)             | = 2.0.0  |
+| <a name="requirement_template"></a> [template](#requirement_template)    | = 2.2.0  |
+| <a name="requirement_time"></a> [time](#requirement_time)                | 0.7.2    |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.2.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_grafana"></a> [grafana](#provider\_grafana) | 1.19.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
-| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.7.2 |
+| Name                                                            | Version |
+| --------------------------------------------------------------- | ------- |
+| <a name="provider_archive"></a> [archive](#provider_archive)    | 2.2.0   |
+| <a name="provider_aws"></a> [aws](#provider_aws)                | 3.75.2  |
+| <a name="provider_grafana"></a> [grafana](#provider_grafana)    | 1.19.0  |
+| <a name="provider_random"></a> [random](#provider_random)       | 3.4.3   |
+| <a name="provider_template"></a> [template](#provider_template) | 2.2.0   |
+| <a name="provider_time"></a> [time](#provider_time)             | 0.7.2   |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_codebuild_monitoring_ecs_alb"></a> [codebuild\_monitoring\_ecs\_alb](#module\_codebuild\_monitoring\_ecs\_alb) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb | n/a |
-| <a name="module_codebuild_monitoring_ecs_cluster"></a> [codebuild\_monitoring\_ecs\_cluster](#module\_codebuild\_monitoring\_ecs\_cluster) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster | n/a |
+| Name                                                                                                                                | Source                                                                                         | Version |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------- |
+| <a name="module_codebuild_monitoring_ecs_alb"></a> [codebuild_monitoring_ecs_alb](#module_codebuild_monitoring_ecs_alb)             | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb | n/a     |
+| <a name="module_codebuild_monitoring_ecs_cluster"></a> [codebuild_monitoring_ecs_cluster](#module_codebuild_monitoring_ecs_cluster) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster     | n/a     |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_cloudwatch_event_rule.codebuild_metrics_lambda](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_target.codebuild_metrics_lambda](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_target) | resource |
-| [aws_cloudwatch_log_group.codebuild_monitoring](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_log_group) | resource |
-| [aws_db_subnet_group.grafana_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/db_subnet_group) | resource |
-| [aws_iam_role.codebuild_metrics_lambda](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.allow_ecs_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.codebuild_metrics_lambda](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_kms_alias.aurora_cluster_encryption_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias) | resource |
-| [aws_kms_alias.logging_encryption_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias) | resource |
-| [aws_kms_key.aurora_cluster_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key) | resource |
-| [aws_kms_key.logging_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key) | resource |
-| [aws_lambda_function.codebuild_metrics_lambda](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function) | resource |
-| [aws_lambda_permission.allow_cloudwatch_to_call_check_foo](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission) | resource |
-| [aws_rds_cluster.grafana_db](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/rds_cluster) | resource |
-| [aws_rds_cluster_instance.grafana_db_instance](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/rds_cluster_instance) | resource |
-| [aws_route53_record.grafana_public_record](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_security_group.grafana_alb_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group) | resource |
-| [aws_security_group.grafana_cluster_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group) | resource |
-| [aws_security_group.grafana_db_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group) | resource |
-| [aws_security_group_rule.allow_db_ingress_from_grafana_containers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_grafana_alb_http_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_grafana_alb_https_egress_to_grafana](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_grafana_alb_https_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_grafana_alb_https_ingress_to_grafana](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_grafana_container_egress_to_world](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_grafana_egress_to_db](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_ssm_parameter.admin_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.grafana_admin_api_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.grafana_admin_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.grafana_admin_username](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.grafana_db_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.grafana_db_username](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.grafana_secret_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.readonly_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [grafana_api_key.admin_api_key](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/api_key) | resource |
-| [grafana_dashboard.codebuild_dashboard](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/dashboard) | resource |
-| [grafana_dashboard.codebuild_ecs_stats](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/dashboard) | resource |
-| [grafana_dashboard.codebuild_last_build_status_dashboard](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/dashboard) | resource |
-| [grafana_dashboard.codebuild_status_dashboard](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/dashboard) | resource |
-| [grafana_data_source.cloudwatch](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/data_source) | resource |
-| [grafana_user.admin_user](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/user) | resource |
-| [grafana_user.readonly_user](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/user) | resource |
-| [random_password.admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [random_password.grafana_admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [random_password.grafana_db_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [random_password.readonly_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [random_string.grafana_admin_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [random_string.grafana_dbuser](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [random_string.grafana_secret_key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [time_sleep.wait_for_containers](https://registry.terraform.io/providers/hashicorp/time/0.7.2/docs/resources/sleep) | resource |
-| [archive_file.codebuild_metrics_payload](https://registry.terraform.io/providers/hashicorp/archive/2.2.0/docs/data-sources/file) | data source |
-| [aws_availability_zones.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_iam_group.admins](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/iam_group) | data source |
-| [aws_iam_group.viewers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/iam_group) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
-| [aws_route53_zone.public_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/route53_zone) | data source |
-| [template_file.allow_kms_access](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.codebuild_metrics_permissions](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.grafana_ecs_task](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
+| Name                                                                                                                                                                  | Type        |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_cloudwatch_event_rule.codebuild_metrics_lambda](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_rule)               | resource    |
+| [aws_cloudwatch_event_target.codebuild_metrics_lambda](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_event_target)           | resource    |
+| [aws_cloudwatch_log_group.codebuild_monitoring](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_log_group)                     | resource    |
+| [aws_db_subnet_group.grafana_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/db_subnet_group)                               | resource    |
+| [aws_iam_role.codebuild_metrics_lambda](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role)                                         | resource    |
+| [aws_iam_role_policy.allow_ecs_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                               | resource    |
+| [aws_iam_role_policy.codebuild_metrics_lambda](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                           | resource    |
+| [aws_kms_alias.aurora_cluster_encryption_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias)                            | resource    |
+| [aws_kms_alias.logging_encryption_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias)                                   | resource    |
+| [aws_kms_key.aurora_cluster_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key)                                      | resource    |
+| [aws_kms_key.logging_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key)                                             | resource    |
+| [aws_lambda_function.codebuild_metrics_lambda](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function)                           | resource    |
+| [aws_lambda_permission.allow_cloudwatch_to_call_check_foo](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission)             | resource    |
+| [aws_rds_cluster.grafana_db](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/rds_cluster)                                                 | resource    |
+| [aws_rds_cluster_instance.grafana_db_instance](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/rds_cluster_instance)                      | resource    |
+| [aws_route53_record.grafana_public_record](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                                | resource    |
+| [aws_security_group.grafana_alb_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group)                           | resource    |
+| [aws_security_group.grafana_cluster_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group)                       | resource    |
+| [aws_security_group.grafana_db_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group)                            | resource    |
+| [aws_security_group_rule.allow_db_ingress_from_grafana_containers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)   | resource    |
+| [aws_security_group_rule.allow_grafana_alb_http_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)             | resource    |
+| [aws_security_group_rule.allow_grafana_alb_https_egress_to_grafana](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)  | resource    |
+| [aws_security_group_rule.allow_grafana_alb_https_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)            | resource    |
+| [aws_security_group_rule.allow_grafana_alb_https_ingress_to_grafana](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource    |
+| [aws_security_group_rule.allow_grafana_container_egress_to_world](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)    | resource    |
+| [aws_security_group_rule.allow_grafana_egress_to_db](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                 | resource    |
+| [aws_ssm_parameter.admin_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                         | resource    |
+| [aws_ssm_parameter.grafana_admin_api_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                  | resource    |
+| [aws_ssm_parameter.grafana_admin_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                 | resource    |
+| [aws_ssm_parameter.grafana_admin_username](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                 | resource    |
+| [aws_ssm_parameter.grafana_db_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                    | resource    |
+| [aws_ssm_parameter.grafana_db_username](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                    | resource    |
+| [aws_ssm_parameter.grafana_secret_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                     | resource    |
+| [aws_ssm_parameter.readonly_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                      | resource    |
+| [grafana_api_key.admin_api_key](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/api_key)                                                | resource    |
+| [grafana_dashboard.codebuild_dashboard](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/dashboard)                                      | resource    |
+| [grafana_dashboard.codebuild_ecs_stats](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/dashboard)                                      | resource    |
+| [grafana_dashboard.codebuild_last_build_status_dashboard](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/dashboard)                    | resource    |
+| [grafana_dashboard.codebuild_status_dashboard](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/dashboard)                               | resource    |
+| [grafana_data_source.cloudwatch](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/data_source)                                           | resource    |
+| [grafana_user.admin_user](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/user)                                                         | resource    |
+| [grafana_user.readonly_user](https://registry.terraform.io/providers/grafana/grafana/1.19.0/docs/resources/user)                                                      | resource    |
+| [random_password.admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password)                                             | resource    |
+| [random_password.grafana_admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password)                                     | resource    |
+| [random_password.grafana_db_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password)                                        | resource    |
+| [random_password.readonly_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password)                                          | resource    |
+| [random_string.grafana_admin_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string)                                           | resource    |
+| [random_string.grafana_dbuser](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string)                                                 | resource    |
+| [random_string.grafana_secret_key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string)                                             | resource    |
+| [time_sleep.wait_for_containers](https://registry.terraform.io/providers/hashicorp/time/0.7.2/docs/resources/sleep)                                                   | resource    |
+| [archive_file.codebuild_metrics_payload](https://registry.terraform.io/providers/hashicorp/archive/2.2.0/docs/data-sources/file)                                      | data source |
+| [aws_availability_zones.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/availability_zones)                                   | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                         | data source |
+| [aws_iam_group.admins](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/iam_group)                                                      | data source |
+| [aws_iam_group.viewers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/iam_group)                                                     | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                                           | data source |
+| [aws_route53_zone.public_zone](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/route53_zone)                                           | data source |
+| [template_file.allow_kms_access](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                             | data source |
+| [template_file.codebuild_metrics_permissions](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                | data source |
+| [template_file.grafana_ecs_task](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                             | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_fargate_cpu"></a> [fargate\_cpu](#input\_fargate\_cpu) | The number of cpu units | `number` | `1024` | no |
-| <a name="input_fargate_memory"></a> [fargate\_memory](#input\_fargate\_memory) | The amount of memory that will be given to fargate in Megabytes | `number` | `2048` | no |
-| <a name="input_grafana_db_instance_class"></a> [grafana\_db\_instance\_class](#input\_grafana\_db\_instance\_class) | The class of DB instance we are using for Grafana | `string` | `"db.t4g.medium"` | no |
-| <a name="input_grafana_db_instance_count"></a> [grafana\_db\_instance\_count](#input\_grafana\_db\_instance\_count) | The number of DB instance we are using for Grafana | `number` | `3` | no |
-| <a name="input_grafana_image"></a> [grafana\_image](#input\_grafana\_image) | The url of our grafana ecs image we want to use | `string` | n/a | yes |
-| <a name="input_grafana_repository_arn"></a> [grafana\_repository\_arn](#input\_grafana\_repository\_arn) | The arn of our grafana repository | `string` | n/a | yes |
-| <a name="input_idle_timeout"></a> [idle\_timeout](#input\_idle\_timeout) | How long in seconds before we terminate a connection | `number` | `180` | no |
-| <a name="input_logging_bucket_name"></a> [logging\_bucket\_name](#input\_logging\_bucket\_name) | The default logging bucket for lb access logs | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | The deployments name | `string` | n/a | yes |
-| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | The private subnets to deploy our db into | `list(string)` | n/a | yes |
-| <a name="input_public_zone_id"></a> [public\_zone\_id](#input\_public\_zone\_id) | The zone id for our public hosted zone so we can use ACM certificates | `string` | n/a | yes |
-| <a name="input_remote_exec_enabled"></a> [remote\_exec\_enabled](#input\_remote\_exec\_enabled) | Do we want to allow remote-exec onto these containers | `bool` | `true` | no |
-| <a name="input_service_subnets"></a> [service\_subnets](#input\_service\_subnets) | A list of our subnets | `list(string)` | n/a | yes |
-| <a name="input_ssl_certificate_arn"></a> [ssl\_certificate\_arn](#input\_ssl\_certificate\_arn) | The arn of our acm certificate | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of environment tags | `map(string)` | `{}` | no |
-| <a name="input_using_smtp_service"></a> [using\_smtp\_service](#input\_using\_smtp\_service) | Are we using the CJSM smtp service | `bool` | `false` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The vpc id for our security groups to bind to | `string` | n/a | yes |
+| Name                                                                                                         | Description                                                           | Type           | Default           | Required |
+| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- | -------------- | ----------------- | :------: |
+| <a name="input_fargate_cpu"></a> [fargate_cpu](#input_fargate_cpu)                                           | The number of cpu units                                               | `number`       | `1024`            |    no    |
+| <a name="input_fargate_memory"></a> [fargate_memory](#input_fargate_memory)                                  | The amount of memory that will be given to fargate in Megabytes       | `number`       | `2048`            |    no    |
+| <a name="input_grafana_db_instance_class"></a> [grafana_db_instance_class](#input_grafana_db_instance_class) | The class of DB instance we are using for Grafana                     | `string`       | `"db.t4g.medium"` |    no    |
+| <a name="input_grafana_db_instance_count"></a> [grafana_db_instance_count](#input_grafana_db_instance_count) | The number of DB instance we are using for Grafana                    | `number`       | `3`               |    no    |
+| <a name="input_grafana_image"></a> [grafana_image](#input_grafana_image)                                     | The url of our grafana ecs image we want to use                       | `string`       | n/a               |   yes    |
+| <a name="input_grafana_repository_arn"></a> [grafana_repository_arn](#input_grafana_repository_arn)          | The arn of our grafana repository                                     | `string`       | n/a               |   yes    |
+| <a name="input_idle_timeout"></a> [idle_timeout](#input_idle_timeout)                                        | How long in seconds before we terminate a connection                  | `number`       | `180`             |    no    |
+| <a name="input_logging_bucket_name"></a> [logging_bucket_name](#input_logging_bucket_name)                   | The default logging bucket for lb access logs                         | `string`       | n/a               |   yes    |
+| <a name="input_name"></a> [name](#input_name)                                                                | The deployments name                                                  | `string`       | n/a               |   yes    |
+| <a name="input_private_subnets"></a> [private_subnets](#input_private_subnets)                               | The private subnets to deploy our db into                             | `list(string)` | n/a               |   yes    |
+| <a name="input_public_zone_id"></a> [public_zone_id](#input_public_zone_id)                                  | The zone id for our public hosted zone so we can use ACM certificates | `string`       | n/a               |   yes    |
+| <a name="input_remote_exec_enabled"></a> [remote_exec_enabled](#input_remote_exec_enabled)                   | Do we want to allow remote-exec onto these containers                 | `bool`         | `true`            |    no    |
+| <a name="input_service_subnets"></a> [service_subnets](#input_service_subnets)                               | A list of our subnets                                                 | `list(string)` | n/a               |   yes    |
+| <a name="input_ssl_certificate_arn"></a> [ssl_certificate_arn](#input_ssl_certificate_arn)                   | The arn of our acm certificate                                        | `string`       | n/a               |   yes    |
+| <a name="input_tags"></a> [tags](#input_tags)                                                                | A map of environment tags                                             | `map(string)`  | `{}`              |    no    |
+| <a name="input_using_smtp_service"></a> [using_smtp_service](#input_using_smtp_service)                      | Are we using the CJSM smtp service                                    | `bool`         | `false`           |    no    |
+| <a name="input_vpc_id"></a> [vpc_id](#input_vpc_id)                                                          | The vpc id for our security groups to bind to                         | `string`       | n/a               |   yes    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_grafana_admin_user_name"></a> [grafana\_admin\_user\_name](#output\_grafana\_admin\_user\_name) | The user name of our grafana admin |
-| <a name="output_grafana_admin_user_password"></a> [grafana\_admin\_user\_password](#output\_grafana\_admin\_user\_password) | The password of our grafana admin |
-| <a name="output_grafana_api_key"></a> [grafana\_api\_key](#output\_grafana\_api\_key) | The api key we can use to provision grafana resources |
-| <a name="output_grafana_external_fqdn"></a> [grafana\_external\_fqdn](#output\_grafana\_external\_fqdn) | The public dns record for our grafana server |
+| Name                                                                                                                 | Description                                           |
+| -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| <a name="output_grafana_admin_user_name"></a> [grafana_admin_user_name](#output_grafana_admin_user_name)             | The user name of our grafana admin                    |
+| <a name="output_grafana_admin_user_password"></a> [grafana_admin_user_password](#output_grafana_admin_user_password) | The password of our grafana admin                     |
+| <a name="output_grafana_api_key"></a> [grafana_api_key](#output_grafana_api_key)                                     | The api key we can use to provision grafana resources |
+| <a name="output_grafana_external_fqdn"></a> [grafana_external_fqdn](#output_grafana_external_fqdn)                   | The public dns record for our grafana server          |
+
 <!-- END_TF_DOCS -->

--- a/modules/monitoring_cluster_ecs/README.md
+++ b/modules/monitoring_cluster_ecs/README.md
@@ -26,7 +26,7 @@ Prometheus alerts are published to slack via SNS and Lambdas. Prometheus data is
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.2.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 | <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
 
 ## Modules

--- a/modules/monitoring_cluster_ecs/README.md
+++ b/modules/monitoring_cluster_ecs/README.md
@@ -11,23 +11,24 @@ Provisions a monitoring cluster with the following components
 Prometheus alerts are published to slack via SNS and Lambdas. Prometheus data is persisted on EFS, dashboards are provisioned inside the docker image
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
-| <a name="requirement_local"></a> [local](#requirement\_local) | = 2.0.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | = 2.2.0 |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
+| <a name="requirement_local"></a> [local](#requirement_local)             | = 2.0.0  |
+| <a name="requirement_template"></a> [template](#requirement_template)    | = 2.2.0  |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.2.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
-| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
+| Name                                                            | Version |
+| --------------------------------------------------------------- | ------- |
+| <a name="provider_archive"></a> [archive](#provider_archive)    | 2.2.0   |
+| <a name="provider_aws"></a> [aws](#provider_aws)                | 3.75.2  |
+| <a name="provider_random"></a> [random](#provider_random)       | 3.4.3   |
+| <a name="provider_template"></a> [template](#provider_template) | 2.2.0   |
 
 ## Modules
 
@@ -35,260 +36,261 @@ No modules.
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_alb.grafana_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb) | resource |
-| [aws_alb.logstash_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb) | resource |
-| [aws_alb.prometheus_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb) | resource |
-| [aws_alb.prometheus_alert_manager_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb) | resource |
-| [aws_alb.prometheus_blackbox_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb) | resource |
-| [aws_alb.prometheus_cloudwatch_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb) | resource |
-| [aws_db_subnet_group.grafana_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/db_subnet_group) | resource |
-| [aws_ecs_cluster.monitoring_cluster](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_cluster) | resource |
-| [aws_ecs_service.grafana_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_service) | resource |
-| [aws_ecs_service.logstash_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_service) | resource |
-| [aws_ecs_service.prometheus_blackbox_exporter_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_service) | resource |
-| [aws_ecs_service.prometheus_cloudwatch_exporter_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_service) | resource |
-| [aws_ecs_service.prometheus_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_service) | resource |
-| [aws_ecs_task_definition.grafana_ecs_task](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_task_definition) | resource |
-| [aws_ecs_task_definition.logstash_tasks](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_task_definition) | resource |
-| [aws_ecs_task_definition.prometheus_blackbox_exporter_tasks](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_task_definition) | resource |
-| [aws_ecs_task_definition.prometheus_cloudwatch_exporter_tasks](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_task_definition) | resource |
-| [aws_ecs_task_definition.prometheus_tasks](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_task_definition) | resource |
-| [aws_iam_policy.allow_ecs_task_secretsmanager](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.prometheus_alerts_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.prometheus_allow_ecr_access](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.prometheus_allow_sns_publish](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.prometheus_cloudwatch_ssm](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy) | resource |
-| [aws_iam_role.prometheus_task_role](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role) | resource |
-| [aws_iam_role.scanning_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.allow_admin_role_cmk_access](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.allow_prometheus_notifications_kms_access](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.allow_ssm_messages](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy_attachment.attach_cloudwatch_readonly](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.attach_ecs_code_deploy_role_for_ecs](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.attach_ecs_task_execution](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.prometheus_allow_ecr_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.prometheus_allow_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.prometheus_allow_sns_publish](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.prometheus_cloudwatch_ssm_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.scanning_lambda_logs](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_kms_alias.alert_notifications_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias) | resource |
-| [aws_kms_alias.aurora_cluster_encryption_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias) | resource |
-| [aws_kms_alias.cluster_logs_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias) | resource |
-| [aws_kms_key.alert_notifications_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key) | resource |
-| [aws_kms_key.aurora_cluster_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key) | resource |
-| [aws_kms_key.cluster_logs_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key) | resource |
-| [aws_lambda_function.prometheus_alerts](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function) | resource |
-| [aws_lambda_permission.prometheus_alerts](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission) | resource |
-| [aws_lb_listener.grafana_http_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener) | resource |
-| [aws_lb_listener.grafana_https_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener) | resource |
-| [aws_lb_listener.logstash_https_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener) | resource |
-| [aws_lb_listener.prometheus_alert_manager_https_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener) | resource |
-| [aws_lb_listener.prometheus_blackbox_exporter_https_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener) | resource |
-| [aws_lb_listener.prometheus_cloudwatch_exporter_https_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener) | resource |
-| [aws_lb_listener.prometheus_http_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener) | resource |
-| [aws_lb_listener.prometheus_https_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener) | resource |
-| [aws_lb_target_group.grafana_alb_target_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_target_group) | resource |
-| [aws_lb_target_group.logstash_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_target_group) | resource |
-| [aws_lb_target_group.prometheus_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_target_group) | resource |
-| [aws_lb_target_group.prometheus_alert_manager_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_target_group) | resource |
-| [aws_lb_target_group.prometheus_blackbox_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_target_group) | resource |
-| [aws_lb_target_group.prometheus_cloudwatch_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_target_group) | resource |
-| [aws_rds_cluster.grafana_db](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/rds_cluster) | resource |
-| [aws_rds_cluster_instance.grafana_db_instance](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/rds_cluster_instance) | resource |
-| [aws_route53_record.db_internal](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_route53_record.grafana_public_record](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_route53_record.logstash_private_dns](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_route53_record.prometheus_alert_manager_internal_record](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_route53_record.prometheus_alert_manager_public_record](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_route53_record.prometheus_blackbox_exporter_private_dns](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_route53_record.prometheus_cloudwatch_exporter_private_dns](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_route53_record.prometheus_internal_record](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_route53_record.prometheus_public_record](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_security_group_rule.allow_all_outbound](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_all_prometheus_outbound](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_audit_logging_bbe_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_bbe_containers_https_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_bbe_containers_https_to_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_bbe_containers_pnc_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_bbe_egress_to_audit_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_bbe_egress_to_bichard7](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_bbe_egress_to_bichard7_backend](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_bbe_egress_to_user_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_bichard7_backend_bbe_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_bichard7_bbe_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_black_box_exporter_alb_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_elasticsearch_egress_from_logstash](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_elasticsearch_ingress_from_logstash](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_http_to_alb_from_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_http_to_alert_manager_alb_from_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_https_to_alert_manager_alb_from_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_ingress_to_black_box_exporter_from_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_logstash_alb_egress_to_logstash_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_logstash_alb_ingress_from_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_logstash_alb_ingress_to_logstash](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_logstash_egress_to_world](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_prometheus_http_alb_egress_from_prometheus](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_prometheus_http_alb_ingress_to_prometheus](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_user_service_bbe_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.grafana_alb_to_grafana_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.grafana_alb_to_vpc_https](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.grafana_containers_to_db](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.grafana_ingress_from_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.grafana_to_postgres](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.grafana_to_world_https](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.nfs_egress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.nfs_egress_udp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.nfs_ingress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.nfs_ingress_udp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.nfs_secure_egress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.nfs_secure_ingress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_alb_allow_https_egress_to_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_alb_allow_https_ingress_from_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_alb_egress_to_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_alb_ingress_from_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_alert_manager_alb_allow_https_egress_to_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_alert_manager_alb_egress_from_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_alert_manager_alb_egress_to_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_alert_manager_alb_ingress_from_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_alert_manager_alb_ingress_to_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_cloudwatch_exporter_egress_to_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_cloudwatch_exporter_ingress_from_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_cloudwatch_exporter_ingress_to_alb_from_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_exporter_scrape_egress_to_prometheus](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_exporter_scrape_ingress_from_prometheus](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_nfs_egress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_nfs_egress_udp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_nfs_ingress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_nfs_ingress_udp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_nfs_secure_egress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_nfs_secure_ingress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_scrape_egress_to_node_exporter](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_scrape_egress_to_postfix_exporter](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_scrape_egress_to_prometheus_black_box_exporter](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_scrape_egress_to_prometheus_exporter](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.prometheus_scrape_ingress_to_prometheus_black_box_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.vpc_to_grafana_alb_http](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.vpc_to_grafana_alb_https](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_sns_topic.alert_notifications](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic) | resource |
-| [aws_sns_topic_policy.default](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic_policy) | resource |
-| [aws_sns_topic_subscription.prometheus_alerts_subscription](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic_subscription) | resource |
-| [aws_ssm_parameter.admin_htaccess_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.admin_htaccess_username](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.grafana_admin_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.grafana_admin_username](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.grafana_db_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.grafana_db_username](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.grafana_secret_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [random_password.admin_htaccess_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [random_password.grafana_admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [random_password.grafana_db_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [random_string.grafana_admin_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [random_string.grafana_dbuser](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [random_string.grafana_secret_key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [archive_file.alert_archive](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
-| [aws_availability_zones.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_cloudwatch_log_group.blackbox_exporter](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/cloudwatch_log_group) | data source |
-| [aws_cloudwatch_log_group.cloudwatch_exporter](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/cloudwatch_log_group) | data source |
-| [aws_cloudwatch_log_group.grafana](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/cloudwatch_log_group) | data source |
-| [aws_cloudwatch_log_group.logstash](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/cloudwatch_log_group) | data source |
-| [aws_iam_role.admin_role](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/iam_role) | data source |
-| [aws_kms_key.secret_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/kms_key) | data source |
-| [aws_lb.audit_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb) | data source |
-| [aws_lb.beanconnect](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb) | data source |
-| [aws_lb.user_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb) | data source |
-| [aws_lb_target_group.app](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb_target_group) | data source |
-| [aws_lb_target_group.audit_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb_target_group) | data source |
-| [aws_lb_target_group.beanconnect](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb_target_group) | data source |
-| [aws_lb_target_group.user_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb_target_group) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
-| [aws_route53_zone.cjse_dot_org](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/route53_zone) | data source |
-| [aws_secretsmanager_secret.os_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/secretsmanager_secret) | data source |
-| [aws_secretsmanager_secret_version.os_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/secretsmanager_secret_version) | data source |
-| [aws_security_group.audit_logging_portal_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.bichard7_alb_backend](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.bichard_alb_web](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.elasticsearch_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.grafana_alb_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.grafana_db_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.grafana_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.logstash_alb_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.logstash_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.prometheus_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.prometheus_alert_manager_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.prometheus_blackbox_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.prometheus_blackbox_exporter_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.prometheus_cloudwatch_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.prometheus_exporter_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.prometheus_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_security_group.user_service_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_ssm_parameter.es_username](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter) | data source |
-| [template_file.alert_webhook_source](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.allow_cmk_admin_access](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.allow_ecr_policy](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.allow_kms_access](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.allow_notifications_kms_access](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.allow_sns_events_publish](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.allow_sns_publish_policy](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.allow_ssm](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.allow_ssm_messages](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.grafana_ecs_task](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.logstash](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.prometheus_blackbox_exporter_ecs_task](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.prometheus_ecs_task](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
-| [template_file.prometheus_exporter_ecs_task](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file) | data source |
+| Name                                                                                                                                                                                      | Type        |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_alb.grafana_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb)                                                                                    | resource    |
+| [aws_alb.logstash_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb)                                                                                   | resource    |
+| [aws_alb.prometheus_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb)                                                                                 | resource    |
+| [aws_alb.prometheus_alert_manager_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb)                                                                   | resource    |
+| [aws_alb.prometheus_blackbox_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb)                                                               | resource    |
+| [aws_alb.prometheus_cloudwatch_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb)                                                             | resource    |
+| [aws_db_subnet_group.grafana_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/db_subnet_group)                                                   | resource    |
+| [aws_ecs_cluster.monitoring_cluster](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_cluster)                                                             | resource    |
+| [aws_ecs_service.grafana_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_service)                                                            | resource    |
+| [aws_ecs_service.logstash_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_service)                                                               | resource    |
+| [aws_ecs_service.prometheus_blackbox_exporter_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_service)                                           | resource    |
+| [aws_ecs_service.prometheus_cloudwatch_exporter_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_service)                                         | resource    |
+| [aws_ecs_service.prometheus_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_service)                                                             | resource    |
+| [aws_ecs_task_definition.grafana_ecs_task](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_task_definition)                                               | resource    |
+| [aws_ecs_task_definition.logstash_tasks](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_task_definition)                                                 | resource    |
+| [aws_ecs_task_definition.prometheus_blackbox_exporter_tasks](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_task_definition)                             | resource    |
+| [aws_ecs_task_definition.prometheus_cloudwatch_exporter_tasks](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_task_definition)                           | resource    |
+| [aws_ecs_task_definition.prometheus_tasks](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ecs_task_definition)                                               | resource    |
+| [aws_iam_policy.allow_ecs_task_secretsmanager](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)                                                    | resource    |
+| [aws_iam_policy.prometheus_alerts_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)                                                        | resource    |
+| [aws_iam_policy.prometheus_allow_ecr_access](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)                                                      | resource    |
+| [aws_iam_policy.prometheus_allow_sns_publish](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)                                                     | resource    |
+| [aws_iam_policy.prometheus_cloudwatch_ssm](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_policy)                                                        | resource    |
+| [aws_iam_role.prometheus_task_role](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role)                                                                 | resource    |
+| [aws_iam_role.scanning_notification](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role)                                                                | resource    |
+| [aws_iam_role_policy.allow_admin_role_cmk_access](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                            | resource    |
+| [aws_iam_role_policy.allow_prometheus_notifications_kms_access](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                              | resource    |
+| [aws_iam_role_policy.allow_ssm_messages](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy)                                                     | resource    |
+| [aws_iam_role_policy_attachment.attach_cloudwatch_readonly](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment)                       | resource    |
+| [aws_iam_role_policy_attachment.attach_ecs_code_deploy_role_for_ecs](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment)              | resource    |
+| [aws_iam_role_policy_attachment.attach_ecs_task_execution](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment)                        | resource    |
+| [aws_iam_role_policy_attachment.prometheus_allow_ecr_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment)                  | resource    |
+| [aws_iam_role_policy_attachment.prometheus_allow_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment)                 | resource    |
+| [aws_iam_role_policy_attachment.prometheus_allow_sns_publish](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment)                     | resource    |
+| [aws_iam_role_policy_attachment.prometheus_cloudwatch_ssm_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment)             | resource    |
+| [aws_iam_role_policy_attachment.scanning_lambda_logs](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/iam_role_policy_attachment)                             | resource    |
+| [aws_kms_alias.alert_notifications_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias)                                                      | resource    |
+| [aws_kms_alias.aurora_cluster_encryption_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias)                                                | resource    |
+| [aws_kms_alias.cluster_logs_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias)                                                        | resource    |
+| [aws_kms_key.alert_notifications_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key)                                                                | resource    |
+| [aws_kms_key.aurora_cluster_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key)                                                          | resource    |
+| [aws_kms_key.cluster_logs_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key)                                                            | resource    |
+| [aws_lambda_function.prometheus_alerts](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_function)                                                      | resource    |
+| [aws_lambda_permission.prometheus_alerts](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lambda_permission)                                                  | resource    |
+| [aws_lb_listener.grafana_http_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener)                                                          | resource    |
+| [aws_lb_listener.grafana_https_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener)                                                         | resource    |
+| [aws_lb_listener.logstash_https_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener)                                                        | resource    |
+| [aws_lb_listener.prometheus_alert_manager_https_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener)                                        | resource    |
+| [aws_lb_listener.prometheus_blackbox_exporter_https_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener)                                    | resource    |
+| [aws_lb_listener.prometheus_cloudwatch_exporter_https_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener)                                  | resource    |
+| [aws_lb_listener.prometheus_http_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener)                                                       | resource    |
+| [aws_lb_listener.prometheus_https_listener](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_listener)                                                      | resource    |
+| [aws_lb_target_group.grafana_alb_target_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_target_group)                                               | resource    |
+| [aws_lb_target_group.logstash_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_target_group)                                                           | resource    |
+| [aws_lb_target_group.prometheus_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_target_group)                                                         | resource    |
+| [aws_lb_target_group.prometheus_alert_manager_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_target_group)                                           | resource    |
+| [aws_lb_target_group.prometheus_blackbox_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_target_group)                                       | resource    |
+| [aws_lb_target_group.prometheus_cloudwatch_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/lb_target_group)                                     | resource    |
+| [aws_rds_cluster.grafana_db](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/rds_cluster)                                                                     | resource    |
+| [aws_rds_cluster_instance.grafana_db_instance](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/rds_cluster_instance)                                          | resource    |
+| [aws_route53_record.db_internal](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                                                              | resource    |
+| [aws_route53_record.grafana_public_record](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                                                    | resource    |
+| [aws_route53_record.logstash_private_dns](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                                                     | resource    |
+| [aws_route53_record.prometheus_alert_manager_internal_record](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                                 | resource    |
+| [aws_route53_record.prometheus_alert_manager_public_record](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                                   | resource    |
+| [aws_route53_record.prometheus_blackbox_exporter_private_dns](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                                 | resource    |
+| [aws_route53_record.prometheus_cloudwatch_exporter_private_dns](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                               | resource    |
+| [aws_route53_record.prometheus_internal_record](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                                               | resource    |
+| [aws_route53_record.prometheus_public_record](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                                                 | resource    |
+| [aws_security_group_rule.allow_all_outbound](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                             | resource    |
+| [aws_security_group_rule.allow_all_prometheus_outbound](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                  | resource    |
+| [aws_security_group_rule.allow_audit_logging_bbe_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                | resource    |
+| [aws_security_group_rule.allow_bbe_containers_https_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                              | resource    |
+| [aws_security_group_rule.allow_bbe_containers_https_to_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                              | resource    |
+| [aws_security_group_rule.allow_bbe_containers_pnc_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                | resource    |
+| [aws_security_group_rule.allow_bbe_egress_to_audit_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                              | resource    |
+| [aws_security_group_rule.allow_bbe_egress_to_bichard7](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                   | resource    |
+| [aws_security_group_rule.allow_bbe_egress_to_bichard7_backend](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                           | resource    |
+| [aws_security_group_rule.allow_bbe_egress_to_user_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                               | resource    |
+| [aws_security_group_rule.allow_bichard7_backend_bbe_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                             | resource    |
+| [aws_security_group_rule.allow_bichard7_bbe_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                     | resource    |
+| [aws_security_group_rule.allow_black_box_exporter_alb_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                            | resource    |
+| [aws_security_group_rule.allow_elasticsearch_egress_from_logstash](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                       | resource    |
+| [aws_security_group_rule.allow_elasticsearch_ingress_from_logstash](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                      | resource    |
+| [aws_security_group_rule.allow_http_to_alb_from_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                     | resource    |
+| [aws_security_group_rule.allow_http_to_alert_manager_alb_from_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                       | resource    |
+| [aws_security_group_rule.allow_https_to_alert_manager_alb_from_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                      | resource    |
+| [aws_security_group_rule.allow_ingress_to_black_box_exporter_from_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                   | resource    |
+| [aws_security_group_rule.allow_logstash_alb_egress_to_logstash_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                | resource    |
+| [aws_security_group_rule.allow_logstash_alb_ingress_from_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                            | resource    |
+| [aws_security_group_rule.allow_logstash_alb_ingress_to_logstash](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                         | resource    |
+| [aws_security_group_rule.allow_logstash_egress_to_world](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                 | resource    |
+| [aws_security_group_rule.allow_prometheus_http_alb_egress_from_prometheus](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)               | resource    |
+| [aws_security_group_rule.allow_prometheus_http_alb_ingress_to_prometheus](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                | resource    |
+| [aws_security_group_rule.allow_user_service_bbe_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                 | resource    |
+| [aws_security_group_rule.grafana_alb_to_grafana_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                               | resource    |
+| [aws_security_group_rule.grafana_alb_to_vpc_https](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                       | resource    |
+| [aws_security_group_rule.grafana_containers_to_db](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                       | resource    |
+| [aws_security_group_rule.grafana_ingress_from_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                       | resource    |
+| [aws_security_group_rule.grafana_to_postgres](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                            | resource    |
+| [aws_security_group_rule.grafana_to_world_https](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                         | resource    |
+| [aws_security_group_rule.nfs_egress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                                 | resource    |
+| [aws_security_group_rule.nfs_egress_udp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                                 | resource    |
+| [aws_security_group_rule.nfs_ingress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                                | resource    |
+| [aws_security_group_rule.nfs_ingress_udp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                                | resource    |
+| [aws_security_group_rule.nfs_secure_egress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                          | resource    |
+| [aws_security_group_rule.nfs_secure_ingress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                         | resource    |
+| [aws_security_group_rule.prometheus_alb_allow_https_egress_to_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                       | resource    |
+| [aws_security_group_rule.prometheus_alb_allow_https_ingress_from_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                    | resource    |
+| [aws_security_group_rule.prometheus_alb_egress_to_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                   | resource    |
+| [aws_security_group_rule.prometheus_alb_ingress_from_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                | resource    |
+| [aws_security_group_rule.prometheus_alert_manager_alb_allow_https_egress_to_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)         | resource    |
+| [aws_security_group_rule.prometheus_alert_manager_alb_egress_from_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)             | resource    |
+| [aws_security_group_rule.prometheus_alert_manager_alb_egress_to_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)               | resource    |
+| [aws_security_group_rule.prometheus_alert_manager_alb_ingress_from_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)            | resource    |
+| [aws_security_group_rule.prometheus_alert_manager_alb_ingress_to_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)              | resource    |
+| [aws_security_group_rule.prometheus_cloudwatch_exporter_egress_to_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                   | resource    |
+| [aws_security_group_rule.prometheus_cloudwatch_exporter_ingress_from_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                | resource    |
+| [aws_security_group_rule.prometheus_cloudwatch_exporter_ingress_to_alb_from_vpc](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)         | resource    |
+| [aws_security_group_rule.prometheus_exporter_scrape_egress_to_prometheus](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                | resource    |
+| [aws_security_group_rule.prometheus_exporter_scrape_ingress_from_prometheus](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)             | resource    |
+| [aws_security_group_rule.prometheus_nfs_egress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                      | resource    |
+| [aws_security_group_rule.prometheus_nfs_egress_udp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                      | resource    |
+| [aws_security_group_rule.prometheus_nfs_ingress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                     | resource    |
+| [aws_security_group_rule.prometheus_nfs_ingress_udp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                     | resource    |
+| [aws_security_group_rule.prometheus_nfs_secure_egress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                               | resource    |
+| [aws_security_group_rule.prometheus_nfs_secure_ingress_tcp](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                              | resource    |
+| [aws_security_group_rule.prometheus_scrape_egress_to_node_exporter](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                      | resource    |
+| [aws_security_group_rule.prometheus_scrape_egress_to_postfix_exporter](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                   | resource    |
+| [aws_security_group_rule.prometheus_scrape_egress_to_prometheus_black_box_exporter](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)      | resource    |
+| [aws_security_group_rule.prometheus_scrape_egress_to_prometheus_exporter](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                | resource    |
+| [aws_security_group_rule.prometheus_scrape_ingress_to_prometheus_black_box_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource    |
+| [aws_security_group_rule.vpc_to_grafana_alb_http](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                        | resource    |
+| [aws_security_group_rule.vpc_to_grafana_alb_https](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                       | resource    |
+| [aws_sns_topic.alert_notifications](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic)                                                                | resource    |
+| [aws_sns_topic_policy.default](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic_policy)                                                              | resource    |
+| [aws_sns_topic_subscription.prometheus_alerts_subscription](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/sns_topic_subscription)                           | resource    |
+| [aws_ssm_parameter.admin_htaccess_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                                    | resource    |
+| [aws_ssm_parameter.admin_htaccess_username](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                                    | resource    |
+| [aws_ssm_parameter.grafana_admin_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                                     | resource    |
+| [aws_ssm_parameter.grafana_admin_username](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                                     | resource    |
+| [aws_ssm_parameter.grafana_db_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                                        | resource    |
+| [aws_ssm_parameter.grafana_db_username](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                                        | resource    |
+| [aws_ssm_parameter.grafana_secret_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                                         | resource    |
+| [random_password.admin_htaccess_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password)                                                        | resource    |
+| [random_password.grafana_admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password)                                                         | resource    |
+| [random_password.grafana_db_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password)                                                            | resource    |
+| [random_string.grafana_admin_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string)                                                               | resource    |
+| [random_string.grafana_dbuser](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string)                                                                     | resource    |
+| [random_string.grafana_secret_key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string)                                                                 | resource    |
+| [archive_file.alert_archive](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file)                                                                     | data source |
+| [aws_availability_zones.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/availability_zones)                                                       | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                                             | data source |
+| [aws_cloudwatch_log_group.blackbox_exporter](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/cloudwatch_log_group)                                         | data source |
+| [aws_cloudwatch_log_group.cloudwatch_exporter](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/cloudwatch_log_group)                                       | data source |
+| [aws_cloudwatch_log_group.grafana](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/cloudwatch_log_group)                                                   | data source |
+| [aws_cloudwatch_log_group.logstash](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/cloudwatch_log_group)                                                  | data source |
+| [aws_iam_role.admin_role](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/iam_role)                                                                        | data source |
+| [aws_kms_key.secret_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/kms_key)                                                               | data source |
+| [aws_lb.audit_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb)                                                                                 | data source |
+| [aws_lb.beanconnect](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb)                                                                                   | data source |
+| [aws_lb.user_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb)                                                                                  | data source |
+| [aws_lb_target_group.app](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb_target_group)                                                                 | data source |
+| [aws_lb_target_group.audit_logging](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb_target_group)                                                       | data source |
+| [aws_lb_target_group.beanconnect](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb_target_group)                                                         | data source |
+| [aws_lb_target_group.user_service](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/lb_target_group)                                                        | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                                                               | data source |
+| [aws_route53_zone.cjse_dot_org](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/route53_zone)                                                              | data source |
+| [aws_secretsmanager_secret.os_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/secretsmanager_secret)                                             | data source |
+| [aws_secretsmanager_secret_version.os_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/secretsmanager_secret_version)                             | data source |
+| [aws_security_group.audit_logging_portal_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                              | data source |
+| [aws_security_group.bichard7_alb_backend](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                                  | data source |
+| [aws_security_group.bichard_alb_web](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                                       | data source |
+| [aws_security_group.elasticsearch_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                          | data source |
+| [aws_security_group.grafana_alb_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                            | data source |
+| [aws_security_group.grafana_db_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                             | data source |
+| [aws_security_group.grafana_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                                | data source |
+| [aws_security_group.logstash_alb_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                           | data source |
+| [aws_security_group.logstash_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                               | data source |
+| [aws_security_group.prometheus_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                                        | data source |
+| [aws_security_group.prometheus_alert_manager_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                          | data source |
+| [aws_security_group.prometheus_blackbox_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                      | data source |
+| [aws_security_group.prometheus_blackbox_exporter_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                           | data source |
+| [aws_security_group.prometheus_cloudwatch_exporter_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                    | data source |
+| [aws_security_group.prometheus_exporter_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                    | data source |
+| [aws_security_group.prometheus_security_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                             | data source |
+| [aws_security_group.user_service_alb](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                                      | data source |
+| [aws_ssm_parameter.es_username](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter)                                                             | data source |
+| [template_file.alert_webhook_source](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                             | data source |
+| [template_file.allow_cmk_admin_access](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                           | data source |
+| [template_file.allow_ecr_policy](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                                 | data source |
+| [template_file.allow_kms_access](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                                 | data source |
+| [template_file.allow_notifications_kms_access](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                   | data source |
+| [template_file.allow_sns_events_publish](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                         | data source |
+| [template_file.allow_sns_publish_policy](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                         | data source |
+| [template_file.allow_ssm](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                                        | data source |
+| [template_file.allow_ssm_messages](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                               | data source |
+| [template_file.grafana_ecs_task](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                                 | data source |
+| [template_file.logstash](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                                         | data source |
+| [template_file.prometheus_blackbox_exporter_ecs_task](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                            | data source |
+| [template_file.prometheus_ecs_task](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                              | data source |
+| [template_file.prometheus_exporter_ecs_task](https://registry.terraform.io/providers/hashicorp/template/2.2.0/docs/data-sources/file)                                                     | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_allowed_ingress_cidr"></a> [allowed\_ingress\_cidr](#input\_allowed\_ingress\_cidr) | An allowed list of ingress CIDRS in our vpc | `list(string)` | n/a | yes |
-| <a name="input_app_targetgroup_arn"></a> [app\_targetgroup\_arn](#input\_app\_targetgroup\_arn) | The arn of our application target group | `string` | n/a | yes |
-| <a name="input_audit_logging_targetgroup_arn"></a> [audit\_logging\_targetgroup\_arn](#input\_audit\_logging\_targetgroup\_arn) | The arn of our audit logging target group | `string` | n/a | yes |
-| <a name="input_beanconnect_targetgroup_arn"></a> [beanconnect\_targetgroup\_arn](#input\_beanconnect\_targetgroup\_arn) | The arn of our beanconnect target group | `string` | n/a | yes |
-| <a name="input_ecs_to_efs_sg_id"></a> [ecs\_to\_efs\_sg\_id](#input\_ecs\_to\_efs\_sg\_id) | The security group id for our ecs/efs communication | `string` | n/a | yes |
-| <a name="input_efs_access_points"></a> [efs\_access\_points](#input\_efs\_access\_points) | A list of efs access points for data storage | `any` | n/a | yes |
-| <a name="input_elasticsearch_host"></a> [elasticsearch\_host](#input\_elasticsearch\_host) | The elasticsearch host | `string` | n/a | yes |
-| <a name="input_environment"></a> [environment](#input\_environment) | The target environment, will map to the terraform workspace | `string` | n/a | yes |
-| <a name="input_fargate_cpu"></a> [fargate\_cpu](#input\_fargate\_cpu) | The number of cpu units | `number` | `1024` | no |
-| <a name="input_fargate_memory"></a> [fargate\_memory](#input\_fargate\_memory) | The amount of memory that will be given to fargate in Megabytes | `number` | `2048` | no |
-| <a name="input_grafana_db_instance_class"></a> [grafana\_db\_instance\_class](#input\_grafana\_db\_instance\_class) | The class of DB instance we are using for Grafana | `string` | `"db.t4g.medium"` | no |
-| <a name="input_grafana_db_instance_count"></a> [grafana\_db\_instance\_count](#input\_grafana\_db\_instance\_count) | The number of DB instance we are using for Grafana | `number` | `3` | no |
-| <a name="input_grafana_image"></a> [grafana\_image](#input\_grafana\_image) | The url of our grafana ecs image we want to use | `string` | n/a | yes |
-| <a name="input_idle_timeout"></a> [idle\_timeout](#input\_idle\_timeout) | How long in seconds before we terminate a connection | `number` | `180` | no |
-| <a name="input_logging_bucket_name"></a> [logging\_bucket\_name](#input\_logging\_bucket\_name) | The default logging bucket for lb access logs | `string` | n/a | yes |
-| <a name="input_logstash_image"></a> [logstash\_image](#input\_logstash\_image) | The logstash image we wish to deploy | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | The deployments name | `string` | n/a | yes |
-| <a name="input_parent_account_id"></a> [parent\_account\_id](#input\_parent\_account\_id) | The id of the parent account | `string` | `null` | no |
-| <a name="input_private_zone_id"></a> [private\_zone\_id](#input\_private\_zone\_id) | The zone id of our privated hosted zone | `string` | n/a | yes |
-| <a name="input_prometheus_blackbox_exporter_image"></a> [prometheus\_blackbox\_exporter\_image](#input\_prometheus\_blackbox\_exporter\_image) | The url of our prometheus blackbox exporter image ecs image we want to use | `string` | n/a | yes |
-| <a name="input_prometheus_cloudwatch_exporter_image"></a> [prometheus\_cloudwatch\_exporter\_image](#input\_prometheus\_cloudwatch\_exporter\_image) | The ecr image we want to deploy | `string` | n/a | yes |
-| <a name="input_prometheus_data_directory"></a> [prometheus\_data\_directory](#input\_prometheus\_data\_directory) | The absolute path where we want to store our Prometheus data | `string` | `"/data"` | no |
-| <a name="input_prometheus_data_retention_days"></a> [prometheus\_data\_retention\_days](#input\_prometheus\_data\_retention\_days) | The number of days we want to store our prometheus data for | `string` | `"180"` | no |
-| <a name="input_prometheus_efs_filesystem_id"></a> [prometheus\_efs\_filesystem\_id](#input\_prometheus\_efs\_filesystem\_id) | The ECS ID to mount our filessytem | `string` | n/a | yes |
-| <a name="input_prometheus_efs_filesystem_path"></a> [prometheus\_efs\_filesystem\_path](#input\_prometheus\_efs\_filesystem\_path) | The ECS ID to mount our filesystem | `string` | `"/data/prometheus"` | no |
-| <a name="input_prometheus_image"></a> [prometheus\_image](#input\_prometheus\_image) | The ecr image we want to deploy | `string` | n/a | yes |
-| <a name="input_prometheus_log_group"></a> [prometheus\_log\_group](#input\_prometheus\_log\_group) | Our prometheus log group | `any` | n/a | yes |
-| <a name="input_public_zone_id"></a> [public\_zone\_id](#input\_public\_zone\_id) | The zone id for our public hosted zone so we can use ACM certificates | `string` | n/a | yes |
-| <a name="input_public_zone_name"></a> [public\_zone\_name](#input\_public\_zone\_name) | The zone name fqdn so we can create a public route53 entry | `string` | n/a | yes |
-| <a name="input_remote_exec_enabled"></a> [remote\_exec\_enabled](#input\_remote\_exec\_enabled) | Do we want to allow remote-exec onto these containers | `bool` | `true` | no |
-| <a name="input_service_subnets"></a> [service\_subnets](#input\_service\_subnets) | A list of our subnets | `list(string)` | n/a | yes |
-| <a name="input_slack_channel_name"></a> [slack\_channel\_name](#input\_slack\_channel\_name) | The slack channel we are going to send our alerts to | `string` | `"moj-cjse-bichard-alerts"` | no |
-| <a name="input_slack_webhook_url"></a> [slack\_webhook\_url](#input\_slack\_webhook\_url) | The slack webhook url we are using to push our notifications | `string` | n/a | yes |
-| <a name="input_ssl_certificate_arn"></a> [ssl\_certificate\_arn](#input\_ssl\_certificate\_arn) | The arn of our ssl certificate | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of environment tags | `map(string)` | `{}` | no |
-| <a name="input_user_service_targetgroup_arn"></a> [user\_service\_targetgroup\_arn](#input\_user\_service\_targetgroup\_arn) | The arn of our user service target group | `string` | n/a | yes |
-| <a name="input_using_smtp_service"></a> [using\_smtp\_service](#input\_using\_smtp\_service) | Are we using the CJSM smtp service | `bool` | `false` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The vpc id for our security groups to bind to | `string` | n/a | yes |
+| Name                                                                                                                                          | Description                                                                | Type           | Default                     | Required |
+| --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------------- | --------------------------- | :------: |
+| <a name="input_allowed_ingress_cidr"></a> [allowed_ingress_cidr](#input_allowed_ingress_cidr)                                                 | An allowed list of ingress CIDRS in our vpc                                | `list(string)` | n/a                         |   yes    |
+| <a name="input_app_targetgroup_arn"></a> [app_targetgroup_arn](#input_app_targetgroup_arn)                                                    | The arn of our application target group                                    | `string`       | n/a                         |   yes    |
+| <a name="input_audit_logging_targetgroup_arn"></a> [audit_logging_targetgroup_arn](#input_audit_logging_targetgroup_arn)                      | The arn of our audit logging target group                                  | `string`       | n/a                         |   yes    |
+| <a name="input_beanconnect_targetgroup_arn"></a> [beanconnect_targetgroup_arn](#input_beanconnect_targetgroup_arn)                            | The arn of our beanconnect target group                                    | `string`       | n/a                         |   yes    |
+| <a name="input_ecs_to_efs_sg_id"></a> [ecs_to_efs_sg_id](#input_ecs_to_efs_sg_id)                                                             | The security group id for our ecs/efs communication                        | `string`       | n/a                         |   yes    |
+| <a name="input_efs_access_points"></a> [efs_access_points](#input_efs_access_points)                                                          | A list of efs access points for data storage                               | `any`          | n/a                         |   yes    |
+| <a name="input_elasticsearch_host"></a> [elasticsearch_host](#input_elasticsearch_host)                                                       | The elasticsearch host                                                     | `string`       | n/a                         |   yes    |
+| <a name="input_environment"></a> [environment](#input_environment)                                                                            | The target environment, will map to the terraform workspace                | `string`       | n/a                         |   yes    |
+| <a name="input_fargate_cpu"></a> [fargate_cpu](#input_fargate_cpu)                                                                            | The number of cpu units                                                    | `number`       | `1024`                      |    no    |
+| <a name="input_fargate_memory"></a> [fargate_memory](#input_fargate_memory)                                                                   | The amount of memory that will be given to fargate in Megabytes            | `number`       | `2048`                      |    no    |
+| <a name="input_grafana_db_instance_class"></a> [grafana_db_instance_class](#input_grafana_db_instance_class)                                  | The class of DB instance we are using for Grafana                          | `string`       | `"db.t4g.medium"`           |    no    |
+| <a name="input_grafana_db_instance_count"></a> [grafana_db_instance_count](#input_grafana_db_instance_count)                                  | The number of DB instance we are using for Grafana                         | `number`       | `3`                         |    no    |
+| <a name="input_grafana_image"></a> [grafana_image](#input_grafana_image)                                                                      | The url of our grafana ecs image we want to use                            | `string`       | n/a                         |   yes    |
+| <a name="input_idle_timeout"></a> [idle_timeout](#input_idle_timeout)                                                                         | How long in seconds before we terminate a connection                       | `number`       | `180`                       |    no    |
+| <a name="input_logging_bucket_name"></a> [logging_bucket_name](#input_logging_bucket_name)                                                    | The default logging bucket for lb access logs                              | `string`       | n/a                         |   yes    |
+| <a name="input_logstash_image"></a> [logstash_image](#input_logstash_image)                                                                   | The logstash image we wish to deploy                                       | `string`       | n/a                         |   yes    |
+| <a name="input_name"></a> [name](#input_name)                                                                                                 | The deployments name                                                       | `string`       | n/a                         |   yes    |
+| <a name="input_parent_account_id"></a> [parent_account_id](#input_parent_account_id)                                                          | The id of the parent account                                               | `string`       | `null`                      |    no    |
+| <a name="input_private_zone_id"></a> [private_zone_id](#input_private_zone_id)                                                                | The zone id of our privated hosted zone                                    | `string`       | n/a                         |   yes    |
+| <a name="input_prometheus_blackbox_exporter_image"></a> [prometheus_blackbox_exporter_image](#input_prometheus_blackbox_exporter_image)       | The url of our prometheus blackbox exporter image ecs image we want to use | `string`       | n/a                         |   yes    |
+| <a name="input_prometheus_cloudwatch_exporter_image"></a> [prometheus_cloudwatch_exporter_image](#input_prometheus_cloudwatch_exporter_image) | The ecr image we want to deploy                                            | `string`       | n/a                         |   yes    |
+| <a name="input_prometheus_data_directory"></a> [prometheus_data_directory](#input_prometheus_data_directory)                                  | The absolute path where we want to store our Prometheus data               | `string`       | `"/data"`                   |    no    |
+| <a name="input_prometheus_data_retention_days"></a> [prometheus_data_retention_days](#input_prometheus_data_retention_days)                   | The number of days we want to store our prometheus data for                | `string`       | `"180"`                     |    no    |
+| <a name="input_prometheus_efs_filesystem_id"></a> [prometheus_efs_filesystem_id](#input_prometheus_efs_filesystem_id)                         | The ECS ID to mount our filessytem                                         | `string`       | n/a                         |   yes    |
+| <a name="input_prometheus_efs_filesystem_path"></a> [prometheus_efs_filesystem_path](#input_prometheus_efs_filesystem_path)                   | The ECS ID to mount our filesystem                                         | `string`       | `"/data/prometheus"`        |    no    |
+| <a name="input_prometheus_image"></a> [prometheus_image](#input_prometheus_image)                                                             | The ecr image we want to deploy                                            | `string`       | n/a                         |   yes    |
+| <a name="input_prometheus_log_group"></a> [prometheus_log_group](#input_prometheus_log_group)                                                 | Our prometheus log group                                                   | `any`          | n/a                         |   yes    |
+| <a name="input_public_zone_id"></a> [public_zone_id](#input_public_zone_id)                                                                   | The zone id for our public hosted zone so we can use ACM certificates      | `string`       | n/a                         |   yes    |
+| <a name="input_public_zone_name"></a> [public_zone_name](#input_public_zone_name)                                                             | The zone name fqdn so we can create a public route53 entry                 | `string`       | n/a                         |   yes    |
+| <a name="input_remote_exec_enabled"></a> [remote_exec_enabled](#input_remote_exec_enabled)                                                    | Do we want to allow remote-exec onto these containers                      | `bool`         | `true`                      |    no    |
+| <a name="input_service_subnets"></a> [service_subnets](#input_service_subnets)                                                                | A list of our subnets                                                      | `list(string)` | n/a                         |   yes    |
+| <a name="input_slack_channel_name"></a> [slack_channel_name](#input_slack_channel_name)                                                       | The slack channel we are going to send our alerts to                       | `string`       | `"moj-cjse-bichard-alerts"` |    no    |
+| <a name="input_slack_webhook_url"></a> [slack_webhook_url](#input_slack_webhook_url)                                                          | The slack webhook url we are using to push our notifications               | `string`       | n/a                         |   yes    |
+| <a name="input_ssl_certificate_arn"></a> [ssl_certificate_arn](#input_ssl_certificate_arn)                                                    | The arn of our ssl certificate                                             | `string`       | n/a                         |   yes    |
+| <a name="input_tags"></a> [tags](#input_tags)                                                                                                 | A map of environment tags                                                  | `map(string)`  | `{}`                        |    no    |
+| <a name="input_user_service_targetgroup_arn"></a> [user_service_targetgroup_arn](#input_user_service_targetgroup_arn)                         | The arn of our user service target group                                   | `string`       | n/a                         |   yes    |
+| <a name="input_using_smtp_service"></a> [using_smtp_service](#input_using_smtp_service)                                                       | Are we using the CJSM smtp service                                         | `bool`         | `false`                     |    no    |
+| <a name="input_vpc_id"></a> [vpc_id](#input_vpc_id)                                                                                           | The vpc id for our security groups to bind to                              | `string`       | n/a                         |   yes    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_alert_manager_external_fqdn"></a> [alert\_manager\_external\_fqdn](#output\_alert\_manager\_external\_fqdn) | The public dns record for our prometheus alert manager |
-| <a name="output_grafana_external_fqdn"></a> [grafana\_external\_fqdn](#output\_grafana\_external\_fqdn) | The public dns record for our grafana server |
-| <a name="output_prometheus_external_fqdn"></a> [prometheus\_external\_fqdn](#output\_prometheus\_external\_fqdn) | The public dns record for our prometheus server |
-| <a name="output_prometheus_internal_fqdn"></a> [prometheus\_internal\_fqdn](#output\_prometheus\_internal\_fqdn) | The private dns record for our prometheus server |
+| Name                                                                                                                 | Description                                            |
+| -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| <a name="output_alert_manager_external_fqdn"></a> [alert_manager_external_fqdn](#output_alert_manager_external_fqdn) | The public dns record for our prometheus alert manager |
+| <a name="output_grafana_external_fqdn"></a> [grafana_external_fqdn](#output_grafana_external_fqdn)                   | The public dns record for our grafana server           |
+| <a name="output_prometheus_external_fqdn"></a> [prometheus_external_fqdn](#output_prometheus_external_fqdn)          | The public dns record for our prometheus server        |
+| <a name="output_prometheus_internal_fqdn"></a> [prometheus_internal_fqdn](#output_prometheus_internal_fqdn)          | The private dns record for our prometheus server       |
+
 <!-- END_TF_DOCS -->

--- a/modules/postfix_vpc/README.md
+++ b/modules/postfix_vpc/README.md
@@ -30,102 +30,105 @@ The `postfix_ecs` variable is a map in the following format
 }
 
 ```
+
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | = 3.75.2 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | = 3.1.0 |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 0.13  |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | = 3.75.2 |
+| <a name="requirement_tls"></a> [tls](#requirement_tls)                   | = 3.1.0  |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
-| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 3.1.0 |
+| Name                                                            | Version |
+| --------------------------------------------------------------- | ------- |
+| <a name="provider_aws"></a> [aws](#provider_aws)                | 3.75.2  |
+| <a name="provider_random"></a> [random](#provider_random)       | 3.4.3   |
+| <a name="provider_template"></a> [template](#provider_template) | 2.2.0   |
+| <a name="provider_tls"></a> [tls](#provider_tls)                | 3.1.0   |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_postfix_ecs_cluster"></a> [postfix\_ecs\_cluster](#module\_postfix\_ecs\_cluster) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster | n/a |
-| <a name="module_postfix_nlb"></a> [postfix\_nlb](#module\_postfix\_nlb) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb | n/a |
-| <a name="module_postfix_vpc"></a> [postfix\_vpc](#module\_postfix\_vpc) | terraform-aws-modules/vpc/aws | 3.0.0 |
-| <a name="module_smtp_nginx_self_signed_certificate"></a> [smtp\_nginx\_self\_signed\_certificate](#module\_smtp\_nginx\_self\_signed\_certificate) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/self_signed_certificate | n/a |
+| Name                                                                                                                                      | Source                                                                                                 | Version |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------- |
+| <a name="module_postfix_ecs_cluster"></a> [postfix_ecs_cluster](#module_postfix_ecs_cluster)                                              | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster             | n/a     |
+| <a name="module_postfix_nlb"></a> [postfix_nlb](#module_postfix_nlb)                                                                      | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/ecs_cluster_alb         | n/a     |
+| <a name="module_postfix_vpc"></a> [postfix_vpc](#module_postfix_vpc)                                                                      | terraform-aws-modules/vpc/aws                                                                          | 3.0.0   |
+| <a name="module_smtp_nginx_self_signed_certificate"></a> [smtp_nginx_self_signed_certificate](#module_smtp_nginx_self_signed_certificate) | github.com/ministryofjustice/bichard7-next-infrastructure-modules.git//modules/self_signed_certificate | n/a     |
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_alb_listener.postfix_ecs_smtps](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb_listener) | resource |
-| [aws_alb_target_group.postfix_smtps](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb_target_group) | resource |
-| [aws_cloudwatch_log_group.postfix_log_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_log_group) | resource |
-| [aws_cloudwatch_metric_alarm.postfix_cluster_cpu_usage](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm) | resource |
-| [aws_cloudwatch_metric_alarm.postfix_cluster_memory_usage](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm) | resource |
-| [aws_cloudwatch_metric_alarm.postfix_service_running_containers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm) | resource |
-| [aws_cloudwatch_metric_alarm.postfix_service_running_tasks](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm) | resource |
-| [aws_eip.nat_gateway_static_ip](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/eip) | resource |
-| [aws_kms_alias.logging_encryption_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias) | resource |
-| [aws_kms_key.logging_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key) | resource |
-| [aws_route53_record.mail](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record) | resource |
-| [aws_s3_bucket.vpc_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_public_access_block.vpc_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_security_group.postfix_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group) | resource |
-| [aws_security_group.postfix_vpc_sg](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group) | resource |
-| [aws_security_group.postfix_vpce](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group) | resource |
-| [aws_security_group_rule.allow_https_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_postfix_vpce_smtp_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_postfix_vpce_smtps_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_smtp_ingress_from_the_application](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_smtp_ingress_from_vpc_to_postfix_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_smtps_from_container_to_cjsm_net](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_smtps_ingress_from_the_application](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_smtps_ingress_from_vpc_to_postfix_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_vpc_endpoint_secure_smtp_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.allow_vpc_endpoint_smtp_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource |
-| [aws_ssm_parameter.postfix_remote_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.postfix_remote_user](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.public_domain_signing_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.public_domain_smtp_csr](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter) | resource |
-| [aws_vpc_endpoint_service.postfix](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/vpc_endpoint_service) | resource |
-| [random_password.postfix_remote_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [tls_cert_request.public_domain_signing_certificate](https://registry.terraform.io/providers/hashicorp/tls/3.1.0/docs/resources/cert_request) | resource |
-| [tls_private_key.public_domain_signing_key](https://registry.terraform.io/providers/hashicorp/tls/3.1.0/docs/resources/private_key) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region) | data source |
-| [aws_route53_zone.public](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/route53_zone) | data source |
-| [aws_security_group.user_service_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group) | data source |
-| [aws_ssm_parameter.cjse_client_certificate](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter) | data source |
-| [aws_ssm_parameter.cjse_relay_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter) | data source |
-| [aws_ssm_parameter.cjse_relay_user](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter) | data source |
-| [aws_ssm_parameter.cjse_root_certificate](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter) | data source |
-| [template_file.allow_kms](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
-| [template_file.postfix_ecs_task](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+| Name                                                                                                                                                                         | Type        |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_alb_listener.postfix_ecs_smtps](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb_listener)                                               | resource    |
+| [aws_alb_target_group.postfix_smtps](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/alb_target_group)                                           | resource    |
+| [aws_cloudwatch_log_group.postfix_log_group](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_log_group)                               | resource    |
+| [aws_cloudwatch_metric_alarm.postfix_cluster_cpu_usage](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm)                 | resource    |
+| [aws_cloudwatch_metric_alarm.postfix_cluster_memory_usage](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm)              | resource    |
+| [aws_cloudwatch_metric_alarm.postfix_service_running_containers](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm)        | resource    |
+| [aws_cloudwatch_metric_alarm.postfix_service_running_tasks](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/cloudwatch_metric_alarm)             | resource    |
+| [aws_eip.nat_gateway_static_ip](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/eip)                                                             | resource    |
+| [aws_kms_alias.logging_encryption_key_alias](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_alias)                                          | resource    |
+| [aws_kms_key.logging_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/kms_key)                                                    | resource    |
+| [aws_route53_record.mail](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/route53_record)                                                        | resource    |
+| [aws_s3_bucket.vpc_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket)                                                  | resource    |
+| [aws_s3_bucket_public_access_block.vpc_flow_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/s3_bucket_public_access_block)          | resource    |
+| [aws_security_group.postfix_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group)                                           | resource    |
+| [aws_security_group.postfix_vpc_sg](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group)                                              | resource    |
+| [aws_security_group.postfix_vpce](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group)                                                | resource    |
+| [aws_security_group_rule.allow_https_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                                | resource    |
+| [aws_security_group_rule.allow_postfix_vpce_smtp_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                    | resource    |
+| [aws_security_group_rule.allow_postfix_vpce_smtps_egress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                   | resource    |
+| [aws_security_group_rule.allow_smtp_ingress_from_the_application](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)           | resource    |
+| [aws_security_group_rule.allow_smtp_ingress_from_vpc_to_postfix_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)  | resource    |
+| [aws_security_group_rule.allow_smtps_from_container_to_cjsm_net](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)            | resource    |
+| [aws_security_group_rule.allow_smtps_ingress_from_the_application](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)          | resource    |
+| [aws_security_group_rule.allow_smtps_ingress_from_vpc_to_postfix_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule) | resource    |
+| [aws_security_group_rule.allow_vpc_endpoint_secure_smtp_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)            | resource    |
+| [aws_security_group_rule.allow_vpc_endpoint_smtp_ingress](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/security_group_rule)                   | resource    |
+| [aws_ssm_parameter.postfix_remote_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                       | resource    |
+| [aws_ssm_parameter.postfix_remote_user](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                           | resource    |
+| [aws_ssm_parameter.public_domain_signing_key](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                     | resource    |
+| [aws_ssm_parameter.public_domain_smtp_csr](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/ssm_parameter)                                        | resource    |
+| [aws_vpc_endpoint_service.postfix](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/resources/vpc_endpoint_service)                                         | resource    |
+| [random_password.postfix_remote_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password)                                           | resource    |
+| [tls_cert_request.public_domain_signing_certificate](https://registry.terraform.io/providers/hashicorp/tls/3.1.0/docs/resources/cert_request)                                | resource    |
+| [tls_private_key.public_domain_signing_key](https://registry.terraform.io/providers/hashicorp/tls/3.1.0/docs/resources/private_key)                                          | resource    |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/caller_identity)                                                | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/region)                                                                  | data source |
+| [aws_route53_zone.public](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/route53_zone)                                                       | data source |
+| [aws_security_group.user_service_container](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/security_group)                                   | data source |
+| [aws_ssm_parameter.cjse_client_certificate](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter)                                    | data source |
+| [aws_ssm_parameter.cjse_relay_password](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter)                                        | data source |
+| [aws_ssm_parameter.cjse_relay_user](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter)                                            | data source |
+| [aws_ssm_parameter.cjse_root_certificate](https://registry.terraform.io/providers/hashicorp/aws/3.75.2/docs/data-sources/ssm_parameter)                                      | data source |
+| [template_file.allow_kms](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file)                                                          | data source |
+| [template_file.postfix_ecs_task](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file)                                                   | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_application_cidr"></a> [application\_cidr](#input\_application\_cidr) | The application cidr block | `list(string)` | n/a | yes |
-| <a name="input_aws_logs_bucket"></a> [aws\_logs\_bucket](#input\_aws\_logs\_bucket) | The bucket we use to log all of our bucket actions | `string` | n/a | yes |
-| <a name="input_cloudwatch_notifications_arn"></a> [cloudwatch\_notifications\_arn](#input\_cloudwatch\_notifications\_arn) | The arn of our cloudwatch sns notifications arn | `string` | n/a | yes |
-| <a name="input_ingress_cidr_blocks"></a> [ingress\_cidr\_blocks](#input\_ingress\_cidr\_blocks) | A list of ingress cidr blocks to route to our private cidrs | `list(string)` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | The name from our label module | `string` | n/a | yes |
-| <a name="input_postfix_ecs"></a> [postfix\_ecs](#input\_postfix\_ecs) | A map of postfix ecr values | `map(string)` | n/a | yes |
-| <a name="input_public_zone_id"></a> [public\_zone\_id](#input\_public\_zone\_id) | The public zone we use to create records on | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of resource tags | `map(string)` | n/a | yes |
-| <a name="input_vpc_cidr_block"></a> [vpc\_cidr\_block](#input\_vpc\_cidr\_block) | Our cidr block to apply to this vpc | `string` | `null` | no |
+| Name                                                                                                                  | Description                                                 | Type           | Default | Required |
+| --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | -------------- | ------- | :------: |
+| <a name="input_application_cidr"></a> [application_cidr](#input_application_cidr)                                     | The application cidr block                                  | `list(string)` | n/a     |   yes    |
+| <a name="input_aws_logs_bucket"></a> [aws_logs_bucket](#input_aws_logs_bucket)                                        | The bucket we use to log all of our bucket actions          | `string`       | n/a     |   yes    |
+| <a name="input_cloudwatch_notifications_arn"></a> [cloudwatch_notifications_arn](#input_cloudwatch_notifications_arn) | The arn of our cloudwatch sns notifications arn             | `string`       | n/a     |   yes    |
+| <a name="input_ingress_cidr_blocks"></a> [ingress_cidr_blocks](#input_ingress_cidr_blocks)                            | A list of ingress cidr blocks to route to our private cidrs | `list(string)` | n/a     |   yes    |
+| <a name="input_name"></a> [name](#input_name)                                                                         | The name from our label module                              | `string`       | n/a     |   yes    |
+| <a name="input_postfix_ecs"></a> [postfix_ecs](#input_postfix_ecs)                                                    | A map of postfix ecr values                                 | `map(string)`  | n/a     |   yes    |
+| <a name="input_public_zone_id"></a> [public_zone_id](#input_public_zone_id)                                           | The public zone we use to create records on                 | `string`       | n/a     |   yes    |
+| <a name="input_tags"></a> [tags](#input_tags)                                                                         | A map of resource tags                                      | `map(string)`  | n/a     |   yes    |
+| <a name="input_vpc_cidr_block"></a> [vpc_cidr_block](#input_vpc_cidr_block)                                           | Our cidr block to apply to this vpc                         | `string`       | `null`  |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_postfix_vpc"></a> [postfix\_vpc](#output\_postfix\_vpc) | The outputs from our postfix VPC |
-| <a name="output_postfix_vpc_nat_gateway_ip"></a> [postfix\_vpc\_nat\_gateway\_ip](#output\_postfix\_vpc\_nat\_gateway\_ip) | The ips of our external nat gateway, this will be presented to cjsm |
-| <a name="output_postfix_vpce_security_group_id"></a> [postfix\_vpce\_security\_group\_id](#output\_postfix\_vpce\_security\_group\_id) | The id of the vpce |
-| <a name="output_postfix_vpce_service"></a> [postfix\_vpce\_service](#output\_postfix\_vpce\_service) | The vpce service we are going to consume in the application |
+| Name                                                                                                                          | Description                                                         |
+| ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| <a name="output_postfix_vpc"></a> [postfix_vpc](#output_postfix_vpc)                                                          | The outputs from our postfix VPC                                    |
+| <a name="output_postfix_vpc_nat_gateway_ip"></a> [postfix_vpc_nat_gateway_ip](#output_postfix_vpc_nat_gateway_ip)             | The ips of our external nat gateway, this will be presented to cjsm |
+| <a name="output_postfix_vpce_security_group_id"></a> [postfix_vpce_security_group_id](#output_postfix_vpce_security_group_id) | The id of the vpce                                                  |
+| <a name="output_postfix_vpce_service"></a> [postfix_vpce_service](#output_postfix_vpce_service)                               | The vpce service we are going to consume in the application         |
+
 <!-- END_TF_DOCS -->

--- a/modules/postfix_vpc/README.md
+++ b/modules/postfix_vpc/README.md
@@ -43,10 +43,10 @@ The `postfix_ecs` variable is a map in the following format
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | = 3.75.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
-| <a name="provider_template"></a> [template](#provider\_template) | n/a |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | = 3.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.75.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+| <a name="provider_template"></a> [template](#provider\_template) | 2.2.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 3.1.0 |
 
 ## Modules
 


### PR DESCRIPTION
This is part 2 of 4 PRs to pin the audit log functions by commit hash through the pipeline so that we deploy the same assets that we have tested.

This PR:

* Adds a lifecycle policy to the s3 bucket that stores this audit logging assets so that they are deleted if they are older than 90 days and have been marked for cleanup (they are marked for clean up by the update params step during production deploy). We need to clean up resources so the s3 bucket doesn't get cluttered.