### PR TITLE
Update default lambda node version to 16

### DIFF
--- a/modules/s3_lambda/variables.tf
+++ b/modules/s3_lambda/variables.tf
@@ -70,7 +70,7 @@ variable "memory_size" {
 variable "lambda_runtime" {
   description = "The runtime we want use for the lambda"
   type        = string
-  default     = "nodejs14.x"
+  default     = "nodejs16.x"
 }
 
 variable "override_function_name" {


### PR DESCRIPTION
This PR updates the default runtime for S3 Lambda modules from Node 14 to Node 16.