### PR TITLE
Add SQS VPC endpoint for Airflow

### DIFF
--- a/modules/base_vpc/main.tf
+++ b/modules/base_vpc/main.tf
@@ -72,6 +72,14 @@ module "vpc_endpoints" {
         Name = "${var.tags["Name"]}-dynamodb"
       }
     },
+    sqs = {
+      service             = "sqs"
+      private_dns_enabled = true
+      subnet_ids          = module.vpc.private_subnets
+      tags = {
+        Name = "${var.tags["Name"]}-sqs"
+      }
+    },
     ssm = {
       service             = "ssm"
       private_dns_enabled = true


### PR DESCRIPTION
This PR adds a new VPC endpoint for SQS. This allows Airflow to communicate with SQS in our VPC.