### PR TITLE
Add airflow VPC endpoints

### DIFF
--- a/modules/base_vpc/main.tf
+++ b/modules/base_vpc/main.tf
@@ -72,6 +72,30 @@ module "vpc_endpoints" {
         Name = "${var.tags["Name"]}-dynamodb"
       }
     },
+    airflow_api = {
+      service             = "airflow.api"
+      private_dns_enabled = true
+      subnet_ids          = module.vpc.private_subnets
+      tags = {
+        Name = "${var.tags["Name"]}-airflow-api"
+      }
+    },
+    airflow_env = {
+      service             = "airflow.env"
+      private_dns_enabled = true
+      subnet_ids          = module.vpc.private_subnets
+      tags = {
+        Name = "${var.tags["Name"]}-airflow-env"
+      }
+    },
+    airflow_ops = {
+      service             = "airflow.ops"
+      private_dns_enabled = true
+      subnet_ids          = module.vpc.private_subnets
+      tags = {
+        Name = "${var.tags["Name"]}-airflow-ops"
+      }
+    },
     sqs = {
       service             = "sqs"
       private_dns_enabled = true


### PR DESCRIPTION
This PR adds the following VPN endpoints:
- `airflow.api`
- `airflow.env`
- `airflow.ops`

This allows our lambdas to access MWAA API inside the VPC.